### PR TITLE
Add beta tramites page with Figma design implementation

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -30,6 +30,11 @@ export const routes: Routes = [
     pathMatch: 'full'
   },
   {
+    path: 'tramites-beta',
+    component: TramitesBetaPageComponent,
+    pathMatch: 'full'
+  },
+  {
     path: 'confirmar',
     component: VerificacionTokenPageComponent,
     pathMatch: 'full'

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import {InicioPageComponent} from './pages/inicio/inicio-page.component';
 import {LoginPageComponent} from './pages/login/login-page.component';
 import {RegistroPageComponent} from './pages/registro/registro-page.component';
 import {TramitesPageComponent} from './pages/tramites/tramites-page.component';
+import {TramitesBetaPageComponent} from './pages/tramites-beta/tramites-beta-page.component';
 import { UnauthenticatedGuard } from './core/auth/guards/unauthenticated.guard';
 import { VerificacionTokenPageComponent } from './pages/verificacion-token/verificacion-token-page.component';
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,42 +1,42 @@
-import { Routes } from '@angular/router';
-import {InicioPageComponent} from './pages/inicio/inicio-page.component';
-import {LoginPageComponent} from './pages/login/login-page.component';
-import {RegistroPageComponent} from './pages/registro/registro-page.component';
-import {TramitesPageComponent} from './pages/tramites/tramites-page.component';
-import {TramitesBetaPageComponent} from './pages/tramites-beta/tramites-beta-page.component';
-import { UnauthenticatedGuard } from './core/auth/guards/unauthenticated.guard';
-import { VerificacionTokenPageComponent } from './pages/verificacion-token/verificacion-token-page.component';
+import { Routes } from "@angular/router";
+import { InicioPageComponent } from "./pages/inicio/inicio-page.component";
+import { LoginPageComponent } from "./pages/login/login-page.component";
+import { RegistroPageComponent } from "./pages/registro/registro-page.component";
+import { TramitesPageComponent } from "./pages/tramites/tramites-page.component";
+import { TramitesBetaPageComponent } from "./pages/tramites-beta/tramites-beta-page.component";
+import { UnauthenticatedGuard } from "./core/auth/guards/unauthenticated.guard";
+import { VerificacionTokenPageComponent } from "./pages/verificacion-token/verificacion-token-page.component";
 
 export const routes: Routes = [
   {
-    path: '',
+    path: "",
     component: InicioPageComponent,
-    pathMatch: 'full'
+    pathMatch: "full",
   },
   {
-    path: 'login',
+    path: "login",
     component: LoginPageComponent,
-    pathMatch: 'full',
-    canMatch: [UnauthenticatedGuard]
+    pathMatch: "full",
+    canMatch: [UnauthenticatedGuard],
   },
   {
-    path: 'registro',
+    path: "registro",
     component: RegistroPageComponent,
-    pathMatch: 'full'
+    pathMatch: "full",
   },
   {
-    path: 'tramites',
+    path: "tramites",
     component: TramitesPageComponent,
-    pathMatch: 'full'
+    pathMatch: "full",
   },
   {
-    path: 'tramites-beta',
+    path: "tramites-beta",
     component: TramitesBetaPageComponent,
-    pathMatch: 'full'
+    pathMatch: "full",
   },
   {
-    path: 'confirmar',
+    path: "confirmar",
     component: VerificacionTokenPageComponent,
-    pathMatch: 'full'
+    pathMatch: "full",
   },
 ];

--- a/src/app/components/pages/tramites/tramite-card/tramite-card.component.html
+++ b/src/app/components/pages/tramites/tramite-card/tramite-card.component.html
@@ -1,21 +1,10 @@
-<div [class]="tramite().isBeta ?
-           'card-tramite bg-gradient-to-br from-green-50 to-emerald-50 border-2 border-green-200 rounded-xl shadow-md hover:shadow-lg transition-all duration-300 overflow-hidden' :
-           'card-tramite bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 overflow-hidden'">
-  <!-- Beta Badge -->
-  @if (tramite().isBeta) {
-    <div class="bg-green-600 text-white text-xs font-bold px-3 py-1 text-center">
-      NUEVA FUNCIONALIDAD - BETA
-    </div>
-  }
-
+<div class="card-tramite bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 overflow-hidden">
   <!-- Card Header -->
   <div class="p-6 pb-4">
     <div class="flex items-start gap-3 mb-4">
       <!-- Ministry Icon -->
-      <div [class]="tramite().isBeta ?
-                   'flex-shrink-0 w-10 h-10 rounded-lg bg-green-100 flex items-center justify-center' :
-                   'flex-shrink-0 w-10 h-10 rounded-lg bg-emerald-100 flex items-center justify-center'">
-        <mat-icon [class]="tramite().isBeta ? 'text-green-600' : 'text-emerald-600'">apartment</mat-icon>
+      <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-emerald-100 flex items-center justify-center">
+        <mat-icon class="text-emerald-600">apartment</mat-icon>
       </div>
 
       <!-- Ministry & Category -->
@@ -23,18 +12,9 @@
         <span class="text-xs font-semibold text-gray-600 uppercase">
           {{ tramite().ministerio }}
         </span>
-        <span
-          [class]="tramite().isBeta ?
-                   'mt-1 inline-block px-3 py-1 text-xs font-medium rounded-full bg-green-100 text-green-700' :
-                   'mt-1 inline-block px-3 py-1 text-xs font-medium rounded-full bg-blue-100 text-blue-600'"
-        >
+        <span class="mt-1 inline-block px-3 py-1 text-xs font-medium rounded-full bg-blue-100 text-blue-600">
           {{ tramite().categoria }}
         </span>
-        @if (tramite().isBeta) {
-          <span class="mt-1 inline-block px-2 py-1 text-xs font-bold rounded-full bg-green-600 text-white">
-            BETA
-          </span>
-        }
       </div>
     </div>
 

--- a/src/app/components/pages/tramites/tramite-card/tramite-card.component.html
+++ b/src/app/components/pages/tramites/tramite-card/tramite-card.component.html
@@ -57,31 +57,25 @@
   <!-- Card Footer -->
   <div class="px-6 py-4">
     <div class="flex flex-col gap-2">
-      @if (tramite().isBeta && tramite().link) {
+      @if (tramite().link) {
         <a
           [routerLink]="tramite().link"
-          class="btn bg-green-600 hover:bg-green-700 text-white flex items-center justify-center gap-2"
+          class="btn btn-primary flex items-center justify-center"
         >
-          <mat-icon class="text-sm">new_releases</mat-icon>
-          Probar Formulario Beta
+          Iniciar Trámite
         </a>
-        <button
-          class="btn btn-outline flex items-center justify-center"
-        >
-          Ver Detalles
-        </button>
       } @else {
         <button
           class="btn btn-primary flex items-center justify-center"
         >
           Iniciar Trámite
         </button>
-        <button
-          class="btn btn-outline flex items-center justify-center"
-        >
-          Ver Detalles
-        </button>
       }
+      <button
+        class="btn btn-outline flex items-center justify-center"
+      >
+        Ver Detalles
+      </button>
     </div>
   </div>
 </div>

--- a/src/app/components/pages/tramites/tramite-card/tramite-card.component.html
+++ b/src/app/components/pages/tramites/tramite-card/tramite-card.component.html
@@ -77,16 +77,31 @@
   <!-- Card Footer -->
   <div class="px-6 py-4">
     <div class="flex flex-col gap-2">
-      <button
-        class="btn btn-primary flex items-center justify-center"
-      >
-        Iniciar Trámite
-      </button>
-      <button
-        class="btn btn-outline flex items-center justify-center"
-      >
-        Ver Detalles
-      </button>
+      @if (tramite().isBeta && tramite().link) {
+        <a
+          [routerLink]="tramite().link"
+          class="btn bg-green-600 hover:bg-green-700 text-white flex items-center justify-center gap-2"
+        >
+          <mat-icon class="text-sm">new_releases</mat-icon>
+          Probar Formulario Beta
+        </a>
+        <button
+          class="btn btn-outline flex items-center justify-center"
+        >
+          Ver Detalles
+        </button>
+      } @else {
+        <button
+          class="btn btn-primary flex items-center justify-center"
+        >
+          Iniciar Trámite
+        </button>
+        <button
+          class="btn btn-outline flex items-center justify-center"
+        >
+          Ver Detalles
+        </button>
+      }
     </div>
   </div>
 </div>

--- a/src/app/components/pages/tramites/tramite-card/tramite-card.component.html
+++ b/src/app/components/pages/tramites/tramite-card/tramite-card.component.html
@@ -1,9 +1,13 @@
-<div class="card-tramite bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 overflow-hidden">
+<div
+  class="card-tramite bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 overflow-hidden"
+>
   <!-- Card Header -->
   <div class="p-6 pb-4">
     <div class="flex items-start gap-3 mb-4">
       <!-- Ministry Icon -->
-      <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-emerald-100 flex items-center justify-center">
+      <div
+        class="flex-shrink-0 w-10 h-10 rounded-lg bg-emerald-100 flex items-center justify-center"
+      >
         <mat-icon class="text-emerald-600">apartment</mat-icon>
       </div>
 
@@ -12,7 +16,9 @@
         <span class="text-xs font-semibold text-gray-600 uppercase">
           {{ tramite().ministerio }}
         </span>
-        <span class="mt-1 inline-block px-3 py-1 text-xs font-medium rounded-full bg-blue-100 text-blue-600">
+        <span
+          class="mt-1 inline-block px-3 py-1 text-xs font-medium rounded-full bg-blue-100 text-blue-600"
+        >
           {{ tramite().categoria }}
         </span>
       </div>
@@ -29,30 +35,38 @@
 
   <!-- Card Content -->
   <div class="px-6 pb-4">
-  <div class="grid grid-cols-2 gap-4">
-    <!-- Duration -->
-    <div class="rounded-lg bg-blue-50 p-4 flex items-center gap-4">
-      <div class="flex items-center gap-2 text-sm font-medium text-blue-600 mb-1">
-        <mat-icon class="text-base">schedule</mat-icon>
+    <div class="grid grid-cols-2 gap-4">
+      <!-- Duration -->
+      <div class="rounded-lg bg-blue-50 p-4 flex items-center gap-4">
+        <div
+          class="flex items-center gap-2 text-sm font-medium text-blue-600 mb-1"
+        >
+          <mat-icon class="text-base">schedule</mat-icon>
+        </div>
+        <div>
+          <div class="text-sm font-semibold text-blue-700">Tiempo</div>
+          <div class="text-blue-900 text-m font-semibold leading-tight">
+            {{ tramite().duracion }}
+          </div>
+        </div>
       </div>
-      <div>
-        <div class="text-sm font-semibold text-blue-700">Tiempo</div>
-        <div class="text-blue-900 text-m font-semibold leading-tight">{{ tramite().duracion }}</div>
-      </div>
-    </div>
 
-    <!-- Cost -->
-    <div class="rounded-lg bg-emerald-50 p-4 flex items-center gap-4">
-      <div class="flex items-center gap-2 text-sm font-medium text-emerald-600 mb-1">
-        <mat-icon class="text-base">attach_money</mat-icon>
-      </div>
-      <div>
-        <div class="text-sm font-semibold text-emerald-700">Costo</div>
-        <div class="text-emerald-900 text-m font-semibold leading-tight">100Q</div>
+      <!-- Cost -->
+      <div class="rounded-lg bg-emerald-50 p-4 flex items-center gap-4">
+        <div
+          class="flex items-center gap-2 text-sm font-medium text-emerald-600 mb-1"
+        >
+          <mat-icon class="text-base">attach_money</mat-icon>
+        </div>
+        <div>
+          <div class="text-sm font-semibold text-emerald-700">Costo</div>
+          <div class="text-emerald-900 text-m font-semibold leading-tight">
+            100Q
+          </div>
+        </div>
       </div>
     </div>
   </div>
-</div>
 
   <!-- Card Footer -->
   <div class="px-6 py-4">
@@ -65,15 +79,11 @@
           Iniciar Trámite
         </a>
       } @else {
-        <button
-          class="btn btn-primary flex items-center justify-center"
-        >
+        <button class="btn btn-primary flex items-center justify-center">
           Iniciar Trámite
         </button>
       }
-      <button
-        class="btn btn-outline flex items-center justify-center"
-      >
+      <button class="btn btn-outline flex items-center justify-center">
         Ver Detalles
       </button>
     </div>

--- a/src/app/components/pages/tramites/tramite-card/tramite-card.component.html
+++ b/src/app/components/pages/tramites/tramite-card/tramite-card.component.html
@@ -1,22 +1,40 @@
-<div class="card-tramite bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 overflow-hidden">
+<div [class]="tramite().isBeta ?
+           'card-tramite bg-gradient-to-br from-green-50 to-emerald-50 border-2 border-green-200 rounded-xl shadow-md hover:shadow-lg transition-all duration-300 overflow-hidden' :
+           'card-tramite bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 overflow-hidden'">
+  <!-- Beta Badge -->
+  @if (tramite().isBeta) {
+    <div class="bg-green-600 text-white text-xs font-bold px-3 py-1 text-center">
+      NUEVA FUNCIONALIDAD - BETA
+    </div>
+  }
+
   <!-- Card Header -->
   <div class="p-6 pb-4">
     <div class="flex items-start gap-3 mb-4">
       <!-- Ministry Icon -->
-      <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-emerald-100 flex items-center justify-center">
-        <mat-icon class="text-emerald-600">apartment</mat-icon>
+      <div [class]="tramite().isBeta ?
+                   'flex-shrink-0 w-10 h-10 rounded-lg bg-green-100 flex items-center justify-center' :
+                   'flex-shrink-0 w-10 h-10 rounded-lg bg-emerald-100 flex items-center justify-center'">
+        <mat-icon [class]="tramite().isBeta ? 'text-green-600' : 'text-emerald-600'">apartment</mat-icon>
       </div>
 
       <!-- Ministry & Category -->
       <div class="flex flex-col">
-                <span class="text-xs font-semibold text-gray-600 uppercase">
-                  {{ tramite().ministerio }}
-                </span>
+        <span class="text-xs font-semibold text-gray-600 uppercase">
+          {{ tramite().ministerio }}
+        </span>
         <span
-          class="mt-1 inline-block px-3 py-1 text-xs font-medium rounded-full bg-blue-100 text-blue-600"
+          [class]="tramite().isBeta ?
+                   'mt-1 inline-block px-3 py-1 text-xs font-medium rounded-full bg-green-100 text-green-700' :
+                   'mt-1 inline-block px-3 py-1 text-xs font-medium rounded-full bg-blue-100 text-blue-600'"
         >
-                  {{ tramite().categoria }}
-                </span>
+          {{ tramite().categoria }}
+        </span>
+        @if (tramite().isBeta) {
+          <span class="mt-1 inline-block px-2 py-1 text-xs font-bold rounded-full bg-green-600 text-white">
+            BETA
+          </span>
+        }
       </div>
     </div>
 

--- a/src/app/components/pages/tramites/tramite-card/tramite-card.component.ts
+++ b/src/app/components/pages/tramites/tramite-card/tramite-card.component.ts
@@ -1,18 +1,14 @@
-import {Component, input} from '@angular/core';
-import { MatIconModule } from '@angular/material/icon';
-import { RouterModule } from '@angular/router';
-import { CommonModule } from '@angular/common';
-import type { tramiteCard } from '../../../../interfaces/pages/tramites-page/tramite.model'
+import { Component, input } from "@angular/core";
+import { MatIconModule } from "@angular/material/icon";
+import { RouterModule } from "@angular/router";
+import { CommonModule } from "@angular/common";
+import type { tramiteCard } from "../../../../interfaces/pages/tramites-page/tramite.model";
 
 @Component({
-  selector: 'app-tramite-card',
-    imports: [
-      CommonModule,
-      MatIconModule,
-      RouterModule,
-    ],
-  templateUrl: './tramite-card.component.html',
-  styleUrl: './tramite-card.component.scss'
+  selector: "app-tramite-card",
+  imports: [CommonModule, MatIconModule, RouterModule],
+  templateUrl: "./tramite-card.component.html",
+  styleUrl: "./tramite-card.component.scss",
 })
 export class TramiteCardComponent {
   tramite = input.required<tramiteCard>();

--- a/src/app/components/pages/tramites/tramite-card/tramite-card.component.ts
+++ b/src/app/components/pages/tramites/tramite-card/tramite-card.component.ts
@@ -1,11 +1,15 @@
 import {Component, input} from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
+import { RouterModule } from '@angular/router';
+import { CommonModule } from '@angular/common';
 import type { tramiteCard } from '../../../../interfaces/pages/tramites-page/tramite.model'
 
 @Component({
   selector: 'app-tramite-card',
     imports: [
+      CommonModule,
       MatIconModule,
+      RouterModule,
     ],
   templateUrl: './tramite-card.component.html',
   styleUrl: './tramite-card.component.scss'

--- a/src/app/components/shared/header/header.component.html
+++ b/src/app/components/shared/header/header.component.html
@@ -25,6 +25,10 @@
       <nav class="hidden lg:flex items-center gap-8">
         <a routerLink="/" class="text-sm font-medium text-gray-700 hover:text-gray-900 transition-colors">Inicio</a>
         <a routerLink="/tramites" class="text-sm font-medium text-gray-700 hover:text-gray-900 transition-colors">Trámites</a>
+        <a routerLink="/tramites-beta" class="text-sm font-medium text-primary hover:text-green-700 transition-colors flex items-center gap-1">
+          Formulario FIABI
+          <span class="text-xs bg-primary text-white px-1.5 py-0.5 rounded-full">BETA</span>
+        </a>
         <a href="#" class="text-sm font-medium text-gray-700 hover:text-gray-900 transition-colors">Seguimiento de Trámite</a>
       </nav>
 

--- a/src/app/components/shared/header/header.component.html
+++ b/src/app/components/shared/header/header.component.html
@@ -5,7 +5,11 @@
     <div class="h-16 flex items-center justify-between gap-4">
       <!-- Mobile Menu Button -->
       <!-- HeaderComponent -->
-      <button class="inline-flex items-center justify-center p-2 rounded-md hover:bg-gray-100 lg:hidden" aria-label="Abrir menú" (click)="toggleMobileMenu()">
+      <button
+        class="inline-flex items-center justify-center p-2 rounded-md hover:bg-gray-100 lg:hidden"
+        aria-label="Abrir menú"
+        (click)="toggleMobileMenu()"
+      >
         <mat-icon>menu</mat-icon>
       </button>
 
@@ -23,28 +27,49 @@
 
       <!-- Desktop Navigation -->
       <nav class="hidden lg:flex items-center gap-8">
-        <a routerLink="/" class="text-sm font-medium text-gray-700 hover:text-gray-900 transition-colors">Inicio</a>
-        <a routerLink="/tramites" class="text-sm font-medium text-gray-700 hover:text-gray-900 transition-colors">Trámites</a>
-        <a routerLink="/tramites-beta" class="text-sm font-medium text-primary hover:text-green-700 transition-colors">
+        <a
+          routerLink="/"
+          class="text-sm font-medium text-gray-700 hover:text-gray-900 transition-colors"
+          >Inicio</a
+        >
+        <a
+          routerLink="/tramites"
+          class="text-sm font-medium text-gray-700 hover:text-gray-900 transition-colors"
+          >Trámites</a
+        >
+        <a
+          routerLink="/tramites-beta"
+          class="text-sm font-medium text-primary hover:text-green-700 transition-colors"
+        >
           Formulario FIABI
         </a>
-        <a href="#" class="text-sm font-medium text-gray-700 hover:text-gray-900 transition-colors">Seguimiento de Trámite</a>
+        <a
+          href="#"
+          class="text-sm font-medium text-gray-700 hover:text-gray-900 transition-colors"
+          >Seguimiento de Trámite</a
+        >
       </nav>
 
       <!-- Auth Buttons -->
       @if (!isMobile()) {
-        @if (authService.authStatus() === 'authenticated') {
-        <div class="hidden lg:flex items-center gap-3">
-          <span class="text-sm font-medium text-gray-700">{{ authService.user()?.nombres }} {{ authService.user()?.apellidos }}</span>
-          <button class="btn btn-outline" (click)="authService.logout()">Cerrar Sesión
-          </button>
-        </div>
+        @if (authService.authStatus() === "authenticated") {
+          <div class="hidden lg:flex items-center gap-3">
+            <span class="text-sm font-medium text-gray-700"
+              >{{ authService.user()?.nombres }}
+              {{ authService.user()?.apellidos }}</span
+            >
+            <button class="btn btn-outline" (click)="authService.logout()">
+              Cerrar Sesión
+            </button>
+          </div>
         } @else {
           <div class="hidden lg:flex items-center gap-3">
-            <button routerLink="/login" class="btn btn-outline">Iniciar Sesión
+            <button routerLink="/login" class="btn btn-outline">
+              Iniciar Sesión
             </button>
-            <button routerLink="/registro" class="btn btn-primary">Regístrate</button>
-
+            <button routerLink="/registro" class="btn btn-primary">
+              Regístrate
+            </button>
           </div>
         }
       }
@@ -58,7 +83,11 @@
       [class.pointer-events-none]="!isMobileMenuOpen"
       (click)="isMobileMenuOpen = false"
     >
-      <div class="absolute inset-0 bg-black/40 transition-opacity" [class.opacity-0]="!isMobileMenuOpen" [class.opacity-100]="isMobileMenuOpen"></div>
+      <div
+        class="absolute inset-0 bg-black/40 transition-opacity"
+        [class.opacity-0]="!isMobileMenuOpen"
+        [class.opacity-100]="isMobileMenuOpen"
+      ></div>
       <div
         class="absolute inset-y-0 left-0 w-80 max-w-full bg-white shadow-xl transform transition-transform flex h-full flex-col z-50"
         [class.-translate-x-full]="!isMobileMenuOpen"
@@ -73,30 +102,40 @@
           <a routerLink="/" class="mobile-nav-link" (click)="toggleMobileMenu()"
             >Inicio</a
           >
-          <a routerLink="/tramites" class="mobile-nav-link" (click)="toggleMobileMenu()"
+          <a
+            routerLink="/tramites"
+            class="mobile-nav-link"
+            (click)="toggleMobileMenu()"
             >Trámites</a
           >
-          <a routerLink="/tramites-beta" class="mobile-nav-link text-primary" (click)="toggleMobileMenu()"
+          <a
+            routerLink="/tramites-beta"
+            class="mobile-nav-link text-primary"
+            (click)="toggleMobileMenu()"
             >Formulario FIABI</a
           >
           <a href="#" class="mobile-nav-link" (click)="toggleMobileMenu()"
             >Seguimiento de Trámite</a
           >
         </nav>
-        @if (authService.authStatus() === 'authenticated') {
+        @if (authService.authStatus() === "authenticated") {
           <div class="p-6 flex flex-col gap-3 mt-auto border-t border-gray-100">
             <button class="btn btn-outline">Cerrar Sesión</button>
           </div>
         } @else {
           <div class="p-6 flex flex-col gap-3 mt-auto border-t border-gray-100">
-            <a routerLink="/login"
+            <a
+              routerLink="/login"
               class="btn btn-outline inline-flex items-center justify-center rounded-md border border-indigo-600 px-4 py-2 text-sm font-medium text-indigo-700 hover:bg-indigo-50"
-              (click)="onNavigateAndClose()">
+              (click)="onNavigateAndClose()"
+            >
               Iniciar Sesión
             </a>
-            <button routerLink="/registro"
+            <button
+              routerLink="/registro"
               class="btn btn-primary inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500"
-              (click)="toggleMobileMenu()">
+              (click)="toggleMobileMenu()"
+            >
               Regístrate
             </button>
           </div>

--- a/src/app/components/shared/header/header.component.html
+++ b/src/app/components/shared/header/header.component.html
@@ -25,9 +25,8 @@
       <nav class="hidden lg:flex items-center gap-8">
         <a routerLink="/" class="text-sm font-medium text-gray-700 hover:text-gray-900 transition-colors">Inicio</a>
         <a routerLink="/tramites" class="text-sm font-medium text-gray-700 hover:text-gray-900 transition-colors">Trámites</a>
-        <a routerLink="/tramites-beta" class="text-sm font-medium text-primary hover:text-green-700 transition-colors flex items-center gap-1">
+        <a routerLink="/tramites-beta" class="text-sm font-medium text-primary hover:text-green-700 transition-colors">
           Formulario FIABI
-          <span class="text-xs bg-primary text-white px-1.5 py-0.5 rounded-full">BETA</span>
         </a>
         <a href="#" class="text-sm font-medium text-gray-700 hover:text-gray-900 transition-colors">Seguimiento de Trámite</a>
       </nav>

--- a/src/app/components/shared/header/header.component.html
+++ b/src/app/components/shared/header/header.component.html
@@ -76,8 +76,8 @@
           <a routerLink="/tramites" class="mobile-nav-link" (click)="toggleMobileMenu()"
             >Trámites</a
           >
-          <a routerLink="/tramites-beta" class="mobile-nav-link text-primary flex items-center gap-2" (click)="toggleMobileMenu()"
-            >Formulario FIABI <span class="text-xs bg-primary text-white px-1.5 py-0.5 rounded-full">BETA</span></a
+          <a routerLink="/tramites-beta" class="mobile-nav-link text-primary" (click)="toggleMobileMenu()"
+            >Formulario FIABI</a
           >
           <a href="#" class="mobile-nav-link" (click)="toggleMobileMenu()"
             >Seguimiento de Trámite</a

--- a/src/app/components/shared/header/header.component.html
+++ b/src/app/components/shared/header/header.component.html
@@ -71,11 +71,14 @@
         role="presentation"
       >
         <nav class="flex flex-col gap-1 p-6">
-          <a href="#" class="mobile-nav-link" (click)="toggleMobileMenu()"
+          <a routerLink="/" class="mobile-nav-link" (click)="toggleMobileMenu()"
             >Inicio</a
           >
-          <a href="#" class="mobile-nav-link" (click)="toggleMobileMenu()"
+          <a routerLink="/tramites" class="mobile-nav-link" (click)="toggleMobileMenu()"
             >Trámites</a
+          >
+          <a routerLink="/tramites-beta" class="mobile-nav-link text-primary flex items-center gap-2" (click)="toggleMobileMenu()"
+            >Formulario FIABI <span class="text-xs bg-primary text-white px-1.5 py-0.5 rounded-full">BETA</span></a
           >
           <a href="#" class="mobile-nav-link" (click)="toggleMobileMenu()"
             >Seguimiento de Trámite</a

--- a/src/app/interfaces/pages/tramites-page/tramite.model.ts
+++ b/src/app/interfaces/pages/tramites-page/tramite.model.ts
@@ -5,5 +5,6 @@ export interface tramiteCard {
   categoria: string,
   ministerio: string,
   duracion: string,
+  isBeta?: boolean;
+  link?: string;
 }
-

--- a/src/app/interfaces/pages/tramites-page/tramite.model.ts
+++ b/src/app/interfaces/pages/tramites-page/tramite.model.ts
@@ -2,9 +2,9 @@ export interface tramiteCard {
   id: number;
   titulo: string;
   descripcion: string;
-  categoria: string,
-  ministerio: string,
-  duracion: string,
+  categoria: string;
+  ministerio: string;
+  duracion: string;
   isBeta?: boolean;
   link?: string;
 }

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.html
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.html
@@ -1,11 +1,11 @@
 <!-- Main Container -->
 <div class="min-h-screen bg-gray-50">
   <!-- Hero Section -->
-  <section class="relative overflow-hidden min-h-[525px] bg-cover bg-center bg-no-repeat"
+  <section class="relative h-[525px] overflow-hidden bg-cover bg-center bg-no-repeat"
            style="background-image: url('https://cdn.builder.io/api/v1/image/assets%2F9513ffe389924175a1d4a897e5c5433b%2F5c12cad17b4f4fa3824a204dede2c230?format=webp&width=800')">
-    
+
     <!-- Green Overlay -->
-    <div class="absolute inset-0 bg-green-600 bg-opacity-80"></div>
+    <div class="absolute inset-0 bg-primary/80"></div>
     
     <!-- Content Container -->
     <div class="relative z-10 pt-24 pb-16 px-4 sm:px-6 lg:px-8">

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.html
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.html
@@ -1,0 +1,250 @@
+<!-- Main Container -->
+<div class="min-h-screen bg-gray-50">
+  <!-- Hero Section -->
+  <section class="relative overflow-hidden min-h-[525px] bg-cover bg-center bg-no-repeat" 
+           style="background-image: url('https://api.builder.io/api/v1/image/assets/9513ffe389924175a1d4a897e5c5433b/600d86ef1a41af4f9e13189ea0220a548871ff59?placeholderIfAbsent=true')">
+    
+    <!-- Green Overlay -->
+    <div class="absolute inset-0 bg-green-600 bg-opacity-80"></div>
+    
+    <!-- Content Container -->
+    <div class="relative z-10 pt-24 pb-16 px-4 sm:px-6 lg:px-8">
+      <div class="max-w-7xl mx-auto">
+        <div class="max-w-4xl mx-auto text-center">
+          
+          <!-- Ministry Badge -->
+          <div class="flex items-center justify-center gap-3 mb-6">
+            <div class="flex items-center justify-center w-16 h-16 bg-white bg-opacity-20 rounded-2xl backdrop-blur-sm">
+              <!-- MARN Icon -->
+              <svg width="32" height="32" viewBox="0 0 33 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M27.8047 3.125V5.625C27.8047 9.49167 27.1214 12.7833 25.7547 15.5C24.488 18.0333 22.6964 19.95 20.3797 21.25C18.1797 22.5 15.6547 23.125 12.8047 23.125H8.10469C7.90469 24.2583 7.80469 25.5083 7.80469 26.875H5.30469C5.30469 25.175 5.44635 23.6167 5.72969 22.2C5.44635 20.5833 5.30469 18.3917 5.30469 15.625C5.30469 13.925 5.62969 12.3 6.27969 10.75C6.91302 9.26667 7.80885 7.94583 8.96719 6.7875C10.1255 5.62917 11.4464 4.73333 12.9297 4.1C14.4797 3.45 16.1047 3.125 17.8047 3.125C18.3047 3.125 19.088 3.20833 20.1547 3.375C21.0214 3.50833 21.7047 3.59167 22.2047 3.625C23.0547 3.69167 23.888 3.7 24.7047 3.65C25.688 3.56667 26.7214 3.39167 27.8047 3.125ZM17.8047 5.625C15.988 5.625 14.3047 6.08333 12.7547 7C11.2547 7.88333 10.063 9.075 9.17969 10.575C8.26302 12.125 7.80469 13.8083 7.80469 15.625V16.925C8.57135 15.725 9.53802 14.6083 10.7047 13.575C11.8214 12.5917 13.1464 11.6667 14.6797 10.8L15.9297 12.95C14.0797 14.0167 12.588 15.1417 11.4547 16.325C10.2547 17.575 9.36302 19.0083 8.77969 20.625H12.8047C15.3214 20.625 17.5089 20.075 19.3672 18.975C21.2255 17.875 22.6547 16.2583 23.6547 14.125C24.7047 11.9083 25.2547 9.23333 25.3047 6.1C24.4714 6.18333 23.6214 6.20833 22.7547 6.175C21.9714 6.125 21.063 6.025 20.0297 5.875C19.2964 5.75833 18.8047 5.6875 18.5547 5.6625C18.3047 5.6375 18.0547 5.625 17.8047 5.625Z" fill="white"/>
+              </svg>
+            </div>
+            
+            <div class="text-left">
+              <div class="text-green-100 text-sm font-semibold tracking-wide uppercase">
+                MINISTERIO DE AMBIENTE
+              </div>
+              <div class="text-white text-lg font-bold">
+                MARN
+              </div>
+            </div>
+          </div>
+
+          <!-- Main Title -->
+          <h1 class="text-4xl md:text-5xl font-bold text-white mb-6 leading-tight">
+            Formulario Instrumento Ambiental Bajo<br>
+            Impacto
+          </h1>
+
+          <!-- Description -->
+          <p class="text-xl text-green-100 mb-8 max-w-3xl mx-auto leading-relaxed">
+            Complete el proceso de evaluación ambiental para su proyecto de manera digital y
+            eficiente
+          </p>
+
+          <!-- Info Pills -->
+          <div class="flex flex-wrap items-center justify-center gap-4 text-green-100">
+            <div class="flex items-center gap-2">
+              <!-- Clock Icon -->
+              <svg width="19" height="19" viewBox="0 0 19 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M9.60938 16.5C8.58938 16.5 7.61438 16.305 6.68437 15.915C5.79437 15.535 5.00187 14.9975 4.30687 14.3025C3.61187 13.6075 3.07437 12.815 2.69437 11.925C2.30437 10.995 2.10938 10.02 2.10938 9C2.10938 7.98 2.30437 7.005 2.69437 6.075C3.07437 5.185 3.61187 4.3925 4.30687 3.6975C5.00187 3.0025 5.79437 2.465 6.68437 2.085C7.61438 1.695 8.58938 1.5 9.60938 1.5C10.6294 1.5 11.6044 1.695 12.5344 2.085C13.4244 2.465 14.2169 3.0025 14.9119 3.6975C15.6069 4.3925 16.1444 5.185 16.5244 6.075C16.9144 7.005 17.1094 7.98 17.1094 9C17.1094 10.02 16.9144 10.995 16.5244 11.925C16.1444 12.815 15.6069 13.6075 14.9119 14.3025C14.2169 14.9975 13.4244 15.535 12.5344 15.915C11.6044 16.305 10.6294 16.5 9.60938 16.5ZM9.60938 15C10.6994 15 11.7094 14.725 12.6394 14.175C13.5394 13.645 14.2544 12.93 14.7844 12.03C15.3344 11.1 15.6094 10.09 15.6094 9C15.6094 7.91 15.3344 6.9 14.7844 5.97C14.2544 5.07 13.5394 4.355 12.6394 3.825C11.7094 3.275 10.6994 3 9.60938 3C8.51937 3 7.50938 3.275 6.57937 3.825C5.67937 4.355 4.96438 5.07 4.43438 5.97C3.88437 6.9 3.60938 7.91 3.60938 9C3.60938 10.09 3.88437 11.1 4.43438 12.03C4.96438 12.93 5.67937 13.645 6.57937 14.175C7.50938 14.725 8.51937 15 9.60938 15ZM10.3594 9H13.3594V10.5H8.85938V5.25H10.3594V9Z" fill="#D1FAE5"/>
+              </svg>
+              <span class="text-base font-medium">Tiempo estimado: 45-90 días</span>
+            </div>
+            
+            <div class="w-px h-6 bg-green-300"></div>
+            
+            <div class="flex items-center gap-2">
+              <!-- Money Icon -->
+              <svg width="20" height="18" viewBox="0 0 20 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M9.73438 16.5C8.71438 16.5 7.73938 16.305 6.80937 15.915C5.91937 15.535 5.12687 14.9975 4.43187 14.3025C3.73687 13.6075 3.19937 12.815 2.81937 11.925C2.42937 10.995 2.23438 10.02 2.23438 9C2.23438 7.98 2.42937 7.005 2.81937 6.075C3.19937 5.185 3.73687 4.3925 4.43187 3.6975C5.12687 3.0025 5.91937 2.465 6.80937 2.085C7.73938 1.695 8.71438 1.5 9.73438 1.5C10.7544 1.5 11.7294 1.695 12.6594 2.085C13.5494 2.465 14.3419 3.0025 15.0369 3.6975C15.7319 4.3925 16.2694 5.185 16.6494 6.075C17.0394 7.005 17.2344 7.98 17.2344 9C17.2344 10.02 17.0394 10.995 16.6494 11.925C16.2694 12.815 15.7319 13.6075 15.0369 14.3025C14.3419 14.9975 13.5494 15.535 12.6594 15.915C11.7294 16.305 10.7544 16.5 9.73438 16.5ZM9.73438 15C10.8244 15 11.8344 14.725 12.7644 14.175C13.6644 13.645 14.3794 12.93 14.9094 12.03C15.4594 11.1 15.7344 10.09 15.7344 9C15.7344 7.91 15.4594 6.9 14.9094 5.97C14.3794 5.07 13.6644 4.355 12.7644 3.825C11.8344 3.275 10.8244 3 9.73438 3C8.64437 3 7.63438 3.275 6.70437 3.825C5.80437 4.355 5.08938 5.07 4.55938 5.97C4.00937 6.9 3.73438 7.91 3.73438 9C3.73438 10.09 4.00937 11.1 4.55938 12.03C5.08938 12.93 5.80437 13.645 6.70437 14.175C7.63438 14.725 8.64437 15 9.73438 15ZM7.10938 10.5H11.2344C11.3344 10.5 11.4219 10.4625 11.4969 10.3875C11.5719 10.3125 11.6094 10.225 11.6094 10.125C11.6094 10.025 11.5719 9.9375 11.4969 9.8625C11.4219 9.7875 11.3344 9.75 11.2344 9.75H8.23438C7.89437 9.75 7.58187 9.665 7.29688 9.495C7.01187 9.325 6.78437 9.0975 6.61438 8.8125C6.44438 8.5275 6.35938 8.215 6.35938 7.875C6.35938 7.535 6.44438 7.2225 6.61438 6.9375C6.78437 6.6525 7.01187 6.425 7.29688 6.255C7.58187 6.085 7.89437 6 8.23438 6H8.98438V4.5H10.4844V6H12.3594V7.5H8.23438C8.13438 7.5 8.04688 7.5375 7.97187 7.6125C7.89687 7.6875 7.85938 7.775 7.85938 7.875C7.85938 7.975 7.89687 8.0625 7.97187 8.1375C8.04688 8.2125 8.13438 8.25 8.23438 8.25H11.2344C11.5744 8.25 11.8869 8.335 12.1719 8.505C12.4569 8.675 12.6844 8.9025 12.8544 9.1875C13.0244 9.4725 13.1094 9.785 13.1094 10.125C13.1094 10.465 13.0244 10.7775 12.8544 11.0625C12.6844 11.3475 12.4569 11.575 12.1719 11.745C11.8869 11.915 11.5744 12 11.2344 12H10.4844V13.5H8.98438V12H7.10938V10.5Z" fill="#D1FAE5"/>
+              </svg>
+              <span class="text-base font-medium">Costo: Q.800 - Q.1,200</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Form Section -->
+  <section class="py-16 px-4 sm:px-6 lg:px-8">
+    <div class="max-w-7xl mx-auto">
+      <div class="flex gap-8">
+        
+        <!-- Sidebar Navigation -->
+        <div class="w-80 flex-shrink-0">
+          <div class="sticky top-8">
+            <div class="bg-white rounded-2xl shadow-lg p-8 max-h-[819px] overflow-y-auto">
+              
+              <!-- Information General Section -->
+              <div class="mb-8">
+                <h3 class="text-sm font-bold text-gray-400 tracking-wider uppercase mb-4">
+                  Información General
+                </h3>
+                
+                <div class="space-y-4">
+                  <!-- Form Steps -->
+                  @for (step of formSteps; track step.numero) {
+                    <div class="flex items-start">
+                      <div class="flex-shrink-0">
+                        <div [class]="step.estado === 'active' ? 
+                                     'w-10 h-10 bg-green-600 text-white rounded-full flex items-center justify-center text-sm font-bold' :
+                                     'w-10 h-10 bg-gray-200 text-gray-600 rounded-full flex items-center justify-center text-sm font-bold'">
+                          {{ step.numero }}
+                        </div>
+                      </div>
+                      <div class="ml-3 flex-1">
+                        <h4 [class]="step.estado === 'active' ? 
+                                     'text-sm font-medium text-green-600 leading-5' :
+                                     'text-sm font-medium text-gray-900 leading-5'">
+                          {{ step.titulo }}
+                        </h4>
+                        <p class="text-xs text-gray-500 mt-1">
+                          {{ step.descripcion }}
+                        </p>
+                      </div>
+                    </div>
+                  }
+                </div>
+              </div>
+
+              <!-- Impactos Ambientales Section -->
+              <div class="mb-8">
+                <h3 class="text-sm font-bold text-gray-400 tracking-wider uppercase mb-4">
+                  Impactos Ambientales
+                </h3>
+                
+                <div class="space-y-4">
+                  @for (impacto of impactosAmbientales; track impacto.numero) {
+                    <div class="flex items-start">
+                      <div class="flex-shrink-0">
+                        <div class="w-10 h-10 bg-gray-200 text-gray-600 rounded-full flex items-center justify-center text-sm font-bold">
+                          {{ impacto.numero }}
+                        </div>
+                      </div>
+                      <div class="ml-3 flex-1">
+                        <h4 class="text-sm font-medium text-gray-900 leading-5">
+                          {{ impacto.titulo }}
+                        </h4>
+                        <p class="text-xs text-gray-500 mt-1">
+                          {{ impacto.descripcion }}
+                        </p>
+                      </div>
+                    </div>
+                  }
+                </div>
+              </div>
+
+              <!-- Requisitos Section -->
+              <div>
+                <h3 class="text-sm font-bold text-gray-400 tracking-wider uppercase mb-4">
+                  Requisitos
+                </h3>
+                
+                <div class="space-y-4">
+                  @for (requisito of requisitos; track requisito.numero) {
+                    <div class="flex items-start">
+                      <div class="flex-shrink-0">
+                        <div class="w-10 h-10 bg-gray-200 text-gray-600 rounded-full flex items-center justify-center text-sm font-bold">
+                          {{ requisito.numero }}
+                        </div>
+                      </div>
+                      <div class="ml-3 flex-1">
+                        <h4 class="text-sm font-medium text-gray-900 leading-5">
+                          {{ requisito.titulo }}
+                        </h4>
+                        <p class="text-xs text-gray-500 mt-1">
+                          {{ requisito.descripcion }}
+                        </p>
+                      </div>
+                    </div>
+                  }
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Main Form Content -->
+        <div class="flex-1">
+          <div class="bg-white rounded-2xl shadow-lg p-12">
+            
+            <!-- Form Header -->
+            <div class="mb-8">
+              <h2 class="text-3xl font-bold text-green-700 mb-6">
+                Formulario Instrumento Ambiental Bajo Impacto
+              </h2>
+              
+              <!-- Tipo de Actividad -->
+              <div class="mb-8">
+                <label class="block text-sm font-semibold text-gray-900 mb-4">
+                  Tipo de Actividad *
+                </label>
+                
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  @for (tipo of tiposActividad; track tipo) {
+                    <button 
+                      type="button"
+                      (click)="selectTipoActividad(tipo)"
+                      [class]="selectedTipoActividad === tipo ? 
+                               'border-2 border-green-500 bg-green-50 text-green-900 p-4 rounded-xl text-left text-sm font-medium transition-all hover:border-green-600' :
+                               'border-2 border-gray-200 bg-white text-gray-900 p-4 rounded-xl text-left text-sm font-medium transition-all hover:border-gray-300'">
+                      {{ tipo }}
+                    </button>
+                  }
+                </div>
+              </div>
+            </div>
+
+            <!-- Form Content Area -->
+            <div class="min-h-[600px] flex items-center justify-center">
+              <div class="text-center text-gray-500">
+                <p class="text-lg">Seleccione un tipo de actividad para continuar</p>
+              </div>
+            </div>
+
+            <!-- Navigation Footer -->
+            <div class="border-t border-gray-200 pt-8 mt-12">
+              <div class="flex items-center justify-between">
+                
+                <!-- Previous Button -->
+                <button 
+                  type="button"
+                  (click)="goToPrevious()"
+                  class="flex items-center gap-2 px-6 py-3 bg-gray-100 text-gray-500 rounded-lg hover:bg-gray-200 transition-colors">
+                  <!-- Previous Icon -->
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M10 12L6 8L10 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                  Anterior
+                </button>
+
+                <!-- Step Counter -->
+                <div class="text-sm text-gray-600">
+                  Paso {{ currentStep }} de {{ totalSteps }}
+                </div>
+
+                <!-- Next Button -->
+                <button 
+                  type="button"
+                  (click)="goToNext()"
+                  [disabled]="!selectedTipoActividad"
+                  [class]="selectedTipoActividad ? 
+                           'flex items-center gap-2 px-8 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors' :
+                           'flex items-center gap-2 px-8 py-3 bg-gray-300 text-gray-500 rounded-lg cursor-not-allowed'">
+                  Continuar
+                  <!-- Next Icon -->
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M6 12L10 8L6 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.html
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.html
@@ -69,8 +69,8 @@
   </section>
 
   <!-- Form Section -->
-  <section class="py-16 px-4 sm:px-6 lg:px-8">
-    <div class="max-w-7xl mx-auto">
+  <section class="px-4 py-16 sm:px-6 lg:px-8">
+    <div class="mx-auto max-w-7xl">
       <div class="flex gap-8">
         
         <!-- Sidebar Navigation -->

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.html
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.html
@@ -89,9 +89,9 @@
                   @for (step of formSteps; track step.numero) {
                     <div class="flex items-start">
                       <div class="flex-shrink-0">
-                        <div [class]="step.estado === 'active' ? 
-                                     'w-10 h-10 bg-green-600 text-white rounded-full flex items-center justify-center text-sm font-bold' :
-                                     'w-10 h-10 bg-gray-200 text-gray-600 rounded-full flex items-center justify-center text-sm font-bold'">
+                        <div [class]="step.estado === 'active' ?
+                                     'flex size-10 items-center justify-center rounded-full bg-primary text-sm font-bold text-white' :
+                                     'flex size-10 items-center justify-center rounded-full bg-gray-200 text-sm font-bold text-gray-600'">
                           {{ step.numero }}
                         </div>
                       </div>

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.html
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.html
@@ -1,64 +1,103 @@
 <!-- Main Container -->
 <div class="min-h-screen bg-gray-50">
   <!-- Hero Section -->
-  <section class="relative h-[525px] overflow-hidden bg-cover bg-center bg-no-repeat"
-           style="background-image: url('https://cdn.builder.io/api/v1/image/assets%2F9513ffe389924175a1d4a897e5c5433b%2Fa821d1fdb5754f818a1b6e736297bc81?format=webp&width=800')">
-
+  <section
+    class="relative h-[525px] overflow-hidden bg-cover bg-center bg-no-repeat"
+    style="
+      background-image: url(&quot;https://cdn.builder.io/api/v1/image/assets%2F9513ffe389924175a1d4a897e5c5433b%2Fa821d1fdb5754f818a1b6e736297bc81?format=webp&width=800&quot;);
+    "
+  >
     <!-- Green Overlay -->
     <div class="absolute inset-0 bg-primary/80"></div>
-    
+
     <!-- Content Container -->
     <div class="relative z-10 pt-24 pb-16 px-4 sm:px-6 lg:px-8">
       <div class="max-w-7xl mx-auto">
         <div class="max-w-4xl mx-auto text-center">
-          
           <!-- Ministry Badge -->
           <div class="flex items-center justify-center gap-3 mb-6">
-            <div class="flex items-center justify-center w-16 h-16 bg-white bg-opacity-20 rounded-2xl backdrop-blur-sm">
+            <div
+              class="flex items-center justify-center w-16 h-16 bg-white bg-opacity-20 rounded-2xl backdrop-blur-sm"
+            >
               <!-- MARN Icon -->
-              <svg width="32" height="32" viewBox="0 0 33 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M27.8047 3.125V5.625C27.8047 9.49167 27.1214 12.7833 25.7547 15.5C24.488 18.0333 22.6964 19.95 20.3797 21.25C18.1797 22.5 15.6547 23.125 12.8047 23.125H8.10469C7.90469 24.2583 7.80469 25.5083 7.80469 26.875H5.30469C5.30469 25.175 5.44635 23.6167 5.72969 22.2C5.44635 20.5833 5.30469 18.3917 5.30469 15.625C5.30469 13.925 5.62969 12.3 6.27969 10.75C6.91302 9.26667 7.80885 7.94583 8.96719 6.7875C10.1255 5.62917 11.4464 4.73333 12.9297 4.1C14.4797 3.45 16.1047 3.125 17.8047 3.125C18.3047 3.125 19.088 3.20833 20.1547 3.375C21.0214 3.50833 21.7047 3.59167 22.2047 3.625C23.0547 3.69167 23.888 3.7 24.7047 3.65C25.688 3.56667 26.7214 3.39167 27.8047 3.125ZM17.8047 5.625C15.988 5.625 14.3047 6.08333 12.7547 7C11.2547 7.88333 10.063 9.075 9.17969 10.575C8.26302 12.125 7.80469 13.8083 7.80469 15.625V16.925C8.57135 15.725 9.53802 14.6083 10.7047 13.575C11.8214 12.5917 13.1464 11.6667 14.6797 10.8L15.9297 12.95C14.0797 14.0167 12.588 15.1417 11.4547 16.325C10.2547 17.575 9.36302 19.0083 8.77969 20.625H12.8047C15.3214 20.625 17.5089 20.075 19.3672 18.975C21.2255 17.875 22.6547 16.2583 23.6547 14.125C24.7047 11.9083 25.2547 9.23333 25.3047 6.1C24.4714 6.18333 23.6214 6.20833 22.7547 6.175C21.9714 6.125 21.063 6.025 20.0297 5.875C19.2964 5.75833 18.8047 5.6875 18.5547 5.6625C18.3047 5.6375 18.0547 5.625 17.8047 5.625Z" fill="white"/>
+              <svg
+                width="32"
+                height="32"
+                viewBox="0 0 33 30"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M27.8047 3.125V5.625C27.8047 9.49167 27.1214 12.7833 25.7547 15.5C24.488 18.0333 22.6964 19.95 20.3797 21.25C18.1797 22.5 15.6547 23.125 12.8047 23.125H8.10469C7.90469 24.2583 7.80469 25.5083 7.80469 26.875H5.30469C5.30469 25.175 5.44635 23.6167 5.72969 22.2C5.44635 20.5833 5.30469 18.3917 5.30469 15.625C5.30469 13.925 5.62969 12.3 6.27969 10.75C6.91302 9.26667 7.80885 7.94583 8.96719 6.7875C10.1255 5.62917 11.4464 4.73333 12.9297 4.1C14.4797 3.45 16.1047 3.125 17.8047 3.125C18.3047 3.125 19.088 3.20833 20.1547 3.375C21.0214 3.50833 21.7047 3.59167 22.2047 3.625C23.0547 3.69167 23.888 3.7 24.7047 3.65C25.688 3.56667 26.7214 3.39167 27.8047 3.125ZM17.8047 5.625C15.988 5.625 14.3047 6.08333 12.7547 7C11.2547 7.88333 10.063 9.075 9.17969 10.575C8.26302 12.125 7.80469 13.8083 7.80469 15.625V16.925C8.57135 15.725 9.53802 14.6083 10.7047 13.575C11.8214 12.5917 13.1464 11.6667 14.6797 10.8L15.9297 12.95C14.0797 14.0167 12.588 15.1417 11.4547 16.325C10.2547 17.575 9.36302 19.0083 8.77969 20.625H12.8047C15.3214 20.625 17.5089 20.075 19.3672 18.975C21.2255 17.875 22.6547 16.2583 23.6547 14.125C24.7047 11.9083 25.2547 9.23333 25.3047 6.1C24.4714 6.18333 23.6214 6.20833 22.7547 6.175C21.9714 6.125 21.063 6.025 20.0297 5.875C19.2964 5.75833 18.8047 5.6875 18.5547 5.6625C18.3047 5.6375 18.0547 5.625 17.8047 5.625Z"
+                  fill="white"
+                />
               </svg>
             </div>
-            
+
             <div class="text-left">
-              <div class="text-green-100 text-sm font-semibold tracking-wide uppercase">
+              <div
+                class="text-green-100 text-sm font-semibold tracking-wide uppercase"
+              >
                 MINISTERIO DE AMBIENTE
               </div>
-              <div class="text-white text-lg font-bold">
-                MARN
-              </div>
+              <div class="text-white text-lg font-bold">MARN</div>
             </div>
           </div>
 
           <!-- Main Title -->
-          <h1 class="text-4xl md:text-5xl font-bold text-white mb-6 leading-tight">
-            Formulario Instrumento Ambiental Bajo<br>
+          <h1
+            class="text-4xl md:text-5xl font-bold text-white mb-6 leading-tight"
+          >
+            Formulario Instrumento Ambiental Bajo<br />
             Impacto
           </h1>
 
           <!-- Description -->
-          <p class="text-xl text-green-100 mb-8 max-w-3xl mx-auto leading-relaxed">
-            Complete el proceso de evaluación ambiental para su proyecto de manera digital y
-            eficiente
+          <p
+            class="text-xl text-green-100 mb-8 max-w-3xl mx-auto leading-relaxed"
+          >
+            Complete el proceso de evaluación ambiental para su proyecto de
+            manera digital y eficiente
           </p>
 
           <!-- Info Pills -->
-          <div class="flex flex-wrap items-center justify-center gap-4 text-green-100">
+          <div
+            class="flex flex-wrap items-center justify-center gap-4 text-green-100"
+          >
             <div class="flex items-center gap-2">
               <!-- Clock Icon -->
-              <svg width="19" height="19" viewBox="0 0 19 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M9.60938 16.5C8.58938 16.5 7.61438 16.305 6.68437 15.915C5.79437 15.535 5.00187 14.9975 4.30687 14.3025C3.61187 13.6075 3.07437 12.815 2.69437 11.925C2.30437 10.995 2.10938 10.02 2.10938 9C2.10938 7.98 2.30437 7.005 2.69437 6.075C3.07437 5.185 3.61187 4.3925 4.30687 3.6975C5.00187 3.0025 5.79437 2.465 6.68437 2.085C7.61438 1.695 8.58938 1.5 9.60938 1.5C10.6294 1.5 11.6044 1.695 12.5344 2.085C13.4244 2.465 14.2169 3.0025 14.9119 3.6975C15.6069 4.3925 16.1444 5.185 16.5244 6.075C16.9144 7.005 17.1094 7.98 17.1094 9C17.1094 10.02 16.9144 10.995 16.5244 11.925C16.1444 12.815 15.6069 13.6075 14.9119 14.3025C14.2169 14.9975 13.4244 15.535 12.5344 15.915C11.6044 16.305 10.6294 16.5 9.60938 16.5ZM9.60938 15C10.6994 15 11.7094 14.725 12.6394 14.175C13.5394 13.645 14.2544 12.93 14.7844 12.03C15.3344 11.1 15.6094 10.09 15.6094 9C15.6094 7.91 15.3344 6.9 14.7844 5.97C14.2544 5.07 13.5394 4.355 12.6394 3.825C11.7094 3.275 10.6994 3 9.60938 3C8.51937 3 7.50938 3.275 6.57937 3.825C5.67937 4.355 4.96438 5.07 4.43438 5.97C3.88437 6.9 3.60938 7.91 3.60938 9C3.60938 10.09 3.88437 11.1 4.43438 12.03C4.96438 12.93 5.67937 13.645 6.57937 14.175C7.50938 14.725 8.51937 15 9.60938 15ZM10.3594 9H13.3594V10.5H8.85938V5.25H10.3594V9Z" fill="#D1FAE5"/>
+              <svg
+                width="19"
+                height="19"
+                viewBox="0 0 19 18"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M9.60938 16.5C8.58938 16.5 7.61438 16.305 6.68437 15.915C5.79437 15.535 5.00187 14.9975 4.30687 14.3025C3.61187 13.6075 3.07437 12.815 2.69437 11.925C2.30437 10.995 2.10938 10.02 2.10938 9C2.10938 7.98 2.30437 7.005 2.69437 6.075C3.07437 5.185 3.61187 4.3925 4.30687 3.6975C5.00187 3.0025 5.79437 2.465 6.68437 2.085C7.61438 1.695 8.58938 1.5 9.60938 1.5C10.6294 1.5 11.6044 1.695 12.5344 2.085C13.4244 2.465 14.2169 3.0025 14.9119 3.6975C15.6069 4.3925 16.1444 5.185 16.5244 6.075C16.9144 7.005 17.1094 7.98 17.1094 9C17.1094 10.02 16.9144 10.995 16.5244 11.925C16.1444 12.815 15.6069 13.6075 14.9119 14.3025C14.2169 14.9975 13.4244 15.535 12.5344 15.915C11.6044 16.305 10.6294 16.5 9.60938 16.5ZM9.60938 15C10.6994 15 11.7094 14.725 12.6394 14.175C13.5394 13.645 14.2544 12.93 14.7844 12.03C15.3344 11.1 15.6094 10.09 15.6094 9C15.6094 7.91 15.3344 6.9 14.7844 5.97C14.2544 5.07 13.5394 4.355 12.6394 3.825C11.7094 3.275 10.6994 3 9.60938 3C8.51937 3 7.50938 3.275 6.57937 3.825C5.67937 4.355 4.96438 5.07 4.43438 5.97C3.88437 6.9 3.60938 7.91 3.60938 9C3.60938 10.09 3.88437 11.1 4.43438 12.03C4.96438 12.93 5.67937 13.645 6.57937 14.175C7.50938 14.725 8.51937 15 9.60938 15ZM10.3594 9H13.3594V10.5H8.85938V5.25H10.3594V9Z"
+                  fill="#D1FAE5"
+                />
               </svg>
-              <span class="text-base font-medium">Tiempo estimado: 45-90 días</span>
+              <span class="text-base font-medium"
+                >Tiempo estimado: 45-90 días</span
+              >
             </div>
-            
+
             <div class="h-6 w-px bg-green-300"></div>
-            
+
             <div class="flex items-center gap-2">
               <!-- Money Icon -->
-              <svg width="20" height="18" viewBox="0 0 20 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path d="M9.73438 16.5C8.71438 16.5 7.73938 16.305 6.80937 15.915C5.91937 15.535 5.12687 14.9975 4.43187 14.3025C3.73687 13.6075 3.19937 12.815 2.81937 11.925C2.42937 10.995 2.23438 10.02 2.23438 9C2.23438 7.98 2.42937 7.005 2.81937 6.075C3.19937 5.185 3.73687 4.3925 4.43187 3.6975C5.12687 3.0025 5.91937 2.465 6.80937 2.085C7.73938 1.695 8.71438 1.5 9.73438 1.5C10.7544 1.5 11.7294 1.695 12.6594 2.085C13.5494 2.465 14.3419 3.0025 15.0369 3.6975C15.7319 4.3925 16.2694 5.185 16.6494 6.075C17.0394 7.005 17.2344 7.98 17.2344 9C17.2344 10.02 17.0394 10.995 16.6494 11.925C16.2694 12.815 15.7319 13.6075 15.0369 14.3025C14.3419 14.9975 13.5494 15.535 12.6594 15.915C11.7294 16.305 10.7544 16.5 9.73438 16.5ZM9.73438 15C10.8244 15 11.8344 14.725 12.7644 14.175C13.6644 13.645 14.3794 12.93 14.9094 12.03C15.4594 11.1 15.7344 10.09 15.7344 9C15.7344 7.91 15.4594 6.9 14.9094 5.97C14.3794 5.07 13.6644 4.355 12.7644 3.825C11.8344 3.275 10.8244 3 9.73438 3C8.64437 3 7.63438 3.275 6.70437 3.825C5.80437 4.355 5.08938 5.07 4.55938 5.97C4.00937 6.9 3.73438 7.91 3.73438 9C3.73438 10.09 4.00937 11.1 4.55938 12.03C5.08938 12.93 5.80437 13.645 6.70437 14.175C7.63438 14.725 8.64437 15 9.73438 15ZM7.10938 10.5H11.2344C11.3344 10.5 11.4219 10.4625 11.4969 10.3875C11.5719 10.3125 11.6094 10.225 11.6094 10.125C11.6094 10.025 11.5719 9.9375 11.4969 9.8625C11.4219 9.7875 11.3344 9.75 11.2344 9.75H8.23438C7.89437 9.75 7.58187 9.665 7.29688 9.495C7.01187 9.325 6.78437 9.0975 6.61438 8.8125C6.44438 8.5275 6.35938 8.215 6.35938 7.875C6.35938 7.535 6.44438 7.2225 6.61438 6.9375C6.78437 6.6525 7.01187 6.425 7.29688 6.255C7.58187 6.085 7.89437 6 8.23438 6H8.98438V4.5H10.4844V6H12.3594V7.5H8.23438C8.13438 7.5 8.04688 7.5375 7.97187 7.6125C7.89687 7.6875 7.85938 7.775 7.85938 7.875C7.85938 7.975 7.89687 8.0625 7.97187 8.1375C8.04688 8.2125 8.13438 8.25 8.23438 8.25H11.2344C11.5744 8.25 11.8869 8.335 12.1719 8.505C12.4569 8.675 12.6844 8.9025 12.8544 9.1875C13.0244 9.4725 13.1094 9.785 13.1094 10.125C13.1094 10.465 13.0244 10.7775 12.8544 11.0625C12.6844 11.3475 12.4569 11.575 12.1719 11.745C11.8869 11.915 11.5744 12 11.2344 12H10.4844V13.5H8.98438V12H7.10938V10.5Z" fill="#D1FAE5"/>
+              <svg
+                width="20"
+                height="18"
+                viewBox="0 0 20 18"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M9.73438 16.5C8.71438 16.5 7.73938 16.305 6.80937 15.915C5.91937 15.535 5.12687 14.9975 4.43187 14.3025C3.73687 13.6075 3.19937 12.815 2.81937 11.925C2.42937 10.995 2.23438 10.02 2.23438 9C2.23438 7.98 2.42937 7.005 2.81937 6.075C3.19937 5.185 3.73687 4.3925 4.43187 3.6975C5.12687 3.0025 5.91937 2.465 6.80937 2.085C7.73938 1.695 8.71438 1.5 9.73438 1.5C10.7544 1.5 11.7294 1.695 12.6594 2.085C13.5494 2.465 14.3419 3.0025 15.0369 3.6975C15.7319 4.3925 16.2694 5.185 16.6494 6.075C17.0394 7.005 17.2344 7.98 17.2344 9C17.2344 10.02 17.0394 10.995 16.6494 11.925C16.2694 12.815 15.7319 13.6075 15.0369 14.3025C14.3419 14.9975 13.5494 15.535 12.6594 15.915C11.7294 16.305 10.7544 16.5 9.73438 16.5ZM9.73438 15C10.8244 15 11.8344 14.725 12.7644 14.175C13.6644 13.645 14.3794 12.93 14.9094 12.03C15.4594 11.1 15.7344 10.09 15.7344 9C15.7344 7.91 15.4594 6.9 14.9094 5.97C14.3794 5.07 13.6644 4.355 12.7644 3.825C11.8344 3.275 10.8244 3 9.73438 3C8.64437 3 7.63438 3.275 6.70437 3.825C5.80437 4.355 5.08938 5.07 4.55938 5.97C4.00937 6.9 3.73438 7.91 3.73438 9C3.73438 10.09 4.00937 11.1 4.55938 12.03C5.08938 12.93 5.80437 13.645 6.70437 14.175C7.63438 14.725 8.64437 15 9.73438 15ZM7.10938 10.5H11.2344C11.3344 10.5 11.4219 10.4625 11.4969 10.3875C11.5719 10.3125 11.6094 10.225 11.6094 10.125C11.6094 10.025 11.5719 9.9375 11.4969 9.8625C11.4219 9.7875 11.3344 9.75 11.2344 9.75H8.23438C7.89437 9.75 7.58187 9.665 7.29688 9.495C7.01187 9.325 6.78437 9.0975 6.61438 8.8125C6.44438 8.5275 6.35938 8.215 6.35938 7.875C6.35938 7.535 6.44438 7.2225 6.61438 6.9375C6.78437 6.6525 7.01187 6.425 7.29688 6.255C7.58187 6.085 7.89437 6 8.23438 6H8.98438V4.5H10.4844V6H12.3594V7.5H8.23438C8.13438 7.5 8.04688 7.5375 7.97187 7.6125C7.89687 7.6875 7.85938 7.775 7.85938 7.875C7.85938 7.975 7.89687 8.0625 7.97187 8.1375C8.04688 8.2125 8.13438 8.25 8.23438 8.25H11.2344C11.5744 8.25 11.8869 8.335 12.1719 8.505C12.4569 8.675 12.6844 8.9025 12.8544 9.1875C13.0244 9.4725 13.1094 9.785 13.1094 10.125C13.1094 10.465 13.0244 10.7775 12.8544 11.0625C12.6844 11.3475 12.4569 11.575 12.1719 11.745C11.8869 11.915 11.5744 12 11.2344 12H10.4844V13.5H8.98438V12H7.10938V10.5Z"
+                  fill="#D1FAE5"
+                />
               </svg>
               <span class="text-base font-medium">Costo: Q.800 - Q.1,200</span>
             </div>
@@ -72,33 +111,43 @@
   <section class="px-4 py-16 sm:px-6 lg:px-8">
     <div class="mx-auto max-w-7xl">
       <div class="flex gap-8 lg:flex-row flex-col">
-        
         <!-- Sidebar Navigation -->
         <div class="w-full lg:w-80 shrink-0">
           <div class="lg:sticky lg:top-8">
-            <div class="max-h-[819px] overflow-y-auto rounded-2xl bg-white p-8 shadow-lg">
-              
+            <div
+              class="max-h-[819px] overflow-y-auto rounded-2xl bg-white p-8 shadow-lg"
+            >
               <!-- Information General Section -->
               <div class="mb-8">
-                <h3 class="text-sm font-bold text-gray-400 tracking-wider uppercase mb-4">
+                <h3
+                  class="text-sm font-bold text-gray-400 tracking-wider uppercase mb-4"
+                >
                   Información General
                 </h3>
-                
+
                 <div class="space-y-4">
                   <!-- Form Steps -->
                   @for (step of formSteps; track step.numero) {
                     <div class="flex items-start">
                       <div class="flex-shrink-0">
-                        <div [class]="step.estado === 'active' ?
-                                     'flex size-10 items-center justify-center rounded-full bg-primary text-sm font-bold text-white' :
-                                     'flex size-10 items-center justify-center rounded-full bg-gray-200 text-sm font-bold text-gray-600'">
+                        <div
+                          [class]="
+                            step.estado === 'active'
+                              ? 'flex size-10 items-center justify-center rounded-full bg-primary text-sm font-bold text-white'
+                              : 'flex size-10 items-center justify-center rounded-full bg-gray-200 text-sm font-bold text-gray-600'
+                          "
+                        >
                           {{ step.numero }}
                         </div>
                       </div>
                       <div class="ml-3 flex-1">
-                        <h4 [class]="step.estado === 'active' ? 
-                                     'text-sm font-medium text-green-600 leading-5' :
-                                     'text-sm font-medium text-gray-900 leading-5'">
+                        <h4
+                          [class]="
+                            step.estado === 'active'
+                              ? 'text-sm font-medium text-green-600 leading-5'
+                              : 'text-sm font-medium text-gray-900 leading-5'
+                          "
+                        >
                           {{ step.titulo }}
                         </h4>
                         <p class="text-xs text-gray-500 mt-1">
@@ -112,15 +161,19 @@
 
               <!-- Impactos Ambientales Section -->
               <div class="mb-8">
-                <h3 class="text-sm font-bold text-gray-400 tracking-wider uppercase mb-4">
+                <h3
+                  class="text-sm font-bold text-gray-400 tracking-wider uppercase mb-4"
+                >
                   Impactos Ambientales
                 </h3>
-                
+
                 <div class="space-y-4">
                   @for (impacto of impactosAmbientales; track impacto.numero) {
                     <div class="flex items-start">
                       <div class="shrink-0">
-                        <div class="flex size-10 items-center justify-center rounded-full bg-gray-200 text-sm font-bold text-gray-600">
+                        <div
+                          class="flex size-10 items-center justify-center rounded-full bg-gray-200 text-sm font-bold text-gray-600"
+                        >
                           {{ impacto.numero }}
                         </div>
                       </div>
@@ -139,15 +192,19 @@
 
               <!-- Requisitos Section -->
               <div>
-                <h3 class="text-sm font-bold text-gray-400 tracking-wider uppercase mb-4">
+                <h3
+                  class="text-sm font-bold text-gray-400 tracking-wider uppercase mb-4"
+                >
                   Requisitos
                 </h3>
-                
+
                 <div class="space-y-4">
                   @for (requisito of requisitos; track requisito.numero) {
                     <div class="flex items-start">
                       <div class="shrink-0">
-                        <div class="flex size-10 items-center justify-center rounded-full bg-gray-200 text-sm font-bold text-gray-600">
+                        <div
+                          class="flex size-10 items-center justify-center rounded-full bg-gray-200 text-sm font-bold text-gray-600"
+                        >
                           {{ requisito.numero }}
                         </div>
                       </div>
@@ -170,27 +227,29 @@
         <!-- Main Form Content -->
         <div class="flex-1">
           <div class="rounded-2xl bg-white p-12 shadow-lg">
-            
             <!-- Form Header -->
             <div class="mb-8">
               <h2 class="text-3xl font-bold text-green-700 mb-6">
                 Formulario Instrumento Ambiental Bajo Impacto
               </h2>
-              
+
               <!-- Tipo de Actividad -->
               <div class="mb-8">
                 <label class="block text-sm font-semibold text-gray-900 mb-4">
                   Tipo de Actividad *
                 </label>
-                
+
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
                   @for (tipo of tiposActividad; track tipo) {
-                    <button 
+                    <button
                       type="button"
                       (click)="selectTipoActividad(tipo)"
-                      [class]="selectedTipoActividad === tipo ? 
-                               'border-2 border-green-500 bg-green-50 text-green-900 p-4 rounded-xl text-left text-sm font-medium transition-all hover:border-green-600' :
-                               'border-2 border-gray-200 bg-white text-gray-900 p-4 rounded-xl text-left text-sm font-medium transition-all hover:border-gray-300'">
+                      [class]="
+                        selectedTipoActividad === tipo
+                          ? 'border-2 border-green-500 bg-green-50 text-green-900 p-4 rounded-xl text-left text-sm font-medium transition-all hover:border-green-600'
+                          : 'border-2 border-gray-200 bg-white text-gray-900 p-4 rounded-xl text-left text-sm font-medium transition-all hover:border-gray-300'
+                      "
+                    >
                       {{ tipo }}
                     </button>
                   }
@@ -201,22 +260,36 @@
             <!-- Form Content Area -->
             <div class="min-h-[600px] flex items-center justify-center">
               <div class="text-center text-gray-500">
-                <p class="text-lg">Seleccione un tipo de actividad para continuar</p>
+                <p class="text-lg">
+                  Seleccione un tipo de actividad para continuar
+                </p>
               </div>
             </div>
 
             <!-- Navigation Footer -->
             <div class="border-t border-gray-200 pt-8 mt-12">
               <div class="flex items-center justify-between">
-                
                 <!-- Previous Button -->
-                <button 
+                <button
                   type="button"
                   (click)="goToPrevious()"
-                  class="flex items-center gap-2 px-6 py-3 bg-gray-100 text-gray-500 rounded-lg hover:bg-gray-200 transition-colors">
+                  class="flex items-center gap-2 px-6 py-3 bg-gray-100 text-gray-500 rounded-lg hover:bg-gray-200 transition-colors"
+                >
                   <!-- Previous Icon -->
-                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M10 12L6 8L10 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M10 12L6 8L10 4"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
                   </svg>
                   Anterior
                 </button>
@@ -227,17 +300,32 @@
                 </div>
 
                 <!-- Next Button -->
-                <button 
+                <button
                   type="button"
                   (click)="goToNext()"
                   [disabled]="!selectedTipoActividad"
-                  [class]="selectedTipoActividad ? 
-                           'flex items-center gap-2 px-8 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors' :
-                           'flex items-center gap-2 px-8 py-3 bg-gray-300 text-gray-500 rounded-lg cursor-not-allowed'">
+                  [class]="
+                    selectedTipoActividad
+                      ? 'flex items-center gap-2 px-8 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors'
+                      : 'flex items-center gap-2 px-8 py-3 bg-gray-300 text-gray-500 rounded-lg cursor-not-allowed'
+                  "
+                >
                   Continuar
                   <!-- Next Icon -->
-                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M6 12L10 8L6 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M6 12L10 8L6 4"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
                   </svg>
                 </button>
               </div>

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.html
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.html
@@ -1,8 +1,8 @@
 <!-- Main Container -->
 <div class="min-h-screen bg-gray-50">
   <!-- Hero Section -->
-  <section class="relative overflow-hidden min-h-[525px] bg-cover bg-center bg-no-repeat" 
-           style="background-image: url('https://api.builder.io/api/v1/image/assets/9513ffe389924175a1d4a897e5c5433b/600d86ef1a41af4f9e13189ea0220a548871ff59?placeholderIfAbsent=true')">
+  <section class="relative overflow-hidden min-h-[525px] bg-cover bg-center bg-no-repeat"
+           style="background-image: url('https://cdn.builder.io/api/v1/image/assets%2F9513ffe389924175a1d4a897e5c5433b%2F5c12cad17b4f4fa3824a204dede2c230?format=webp&width=800')">
     
     <!-- Green Overlay -->
     <div class="absolute inset-0 bg-green-600 bg-opacity-80"></div>

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.html
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.html
@@ -2,7 +2,7 @@
 <div class="min-h-screen bg-gray-50">
   <!-- Hero Section -->
   <section class="relative h-[525px] overflow-hidden bg-cover bg-center bg-no-repeat"
-           style="background-image: url('https://cdn.builder.io/api/v1/image/assets%2F9513ffe389924175a1d4a897e5c5433b%2F5c12cad17b4f4fa3824a204dede2c230?format=webp&width=800')">
+           style="background-image: url('https://cdn.builder.io/api/v1/image/assets%2F9513ffe389924175a1d4a897e5c5433b%2F85fe6f21b0c446faac070da5a76531bc?format=webp&width=800')">
 
     <!-- Green Overlay -->
     <div class="absolute inset-0 bg-primary/80"></div>

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.html
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.html
@@ -74,9 +74,9 @@
       <div class="flex gap-8">
         
         <!-- Sidebar Navigation -->
-        <div class="w-80 flex-shrink-0">
+        <div class="w-80 shrink-0">
           <div class="sticky top-8">
-            <div class="bg-white rounded-2xl shadow-lg p-8 max-h-[819px] overflow-y-auto">
+            <div class="max-h-[819px] overflow-y-auto rounded-2xl bg-white p-8 shadow-lg">
               
               <!-- Information General Section -->
               <div class="mb-8">

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.html
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.html
@@ -74,7 +74,7 @@
       <div class="flex gap-8 lg:flex-row flex-col">
         
         <!-- Sidebar Navigation -->
-        <div class="w-80 shrink-0">
+        <div class="w-full lg:w-80 shrink-0">
           <div class="sticky top-8">
             <div class="max-h-[819px] overflow-y-auto rounded-2xl bg-white p-8 shadow-lg">
               

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.html
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.html
@@ -119,8 +119,8 @@
                 <div class="space-y-4">
                   @for (impacto of impactosAmbientales; track impacto.numero) {
                     <div class="flex items-start">
-                      <div class="flex-shrink-0">
-                        <div class="w-10 h-10 bg-gray-200 text-gray-600 rounded-full flex items-center justify-center text-sm font-bold">
+                      <div class="shrink-0">
+                        <div class="flex size-10 items-center justify-center rounded-full bg-gray-200 text-sm font-bold text-gray-600">
                           {{ impacto.numero }}
                         </div>
                       </div>
@@ -146,8 +146,8 @@
                 <div class="space-y-4">
                   @for (requisito of requisitos; track requisito.numero) {
                     <div class="flex items-start">
-                      <div class="flex-shrink-0">
-                        <div class="w-10 h-10 bg-gray-200 text-gray-600 rounded-full flex items-center justify-center text-sm font-bold">
+                      <div class="shrink-0">
+                        <div class="flex size-10 items-center justify-center rounded-full bg-gray-200 text-sm font-bold text-gray-600">
                           {{ requisito.numero }}
                         </div>
                       </div>

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.html
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.html
@@ -2,7 +2,7 @@
 <div class="min-h-screen bg-gray-50">
   <!-- Hero Section -->
   <section class="relative h-[525px] overflow-hidden bg-cover bg-center bg-no-repeat"
-           style="background-image: url('https://cdn.builder.io/api/v1/image/assets%2F9513ffe389924175a1d4a897e5c5433b%2F85fe6f21b0c446faac070da5a76531bc?format=webp&width=800')">
+           style="background-image: url('https://cdn.builder.io/api/v1/image/assets%2F9513ffe389924175a1d4a897e5c5433b%2Fa821d1fdb5754f818a1b6e736297bc81?format=webp&width=800')">
 
     <!-- Green Overlay -->
     <div class="absolute inset-0 bg-primary/80"></div>

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.html
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.html
@@ -75,7 +75,7 @@
         
         <!-- Sidebar Navigation -->
         <div class="w-full lg:w-80 shrink-0">
-          <div class="sticky top-8">
+          <div class="lg:sticky lg:top-8">
             <div class="max-h-[819px] overflow-y-auto rounded-2xl bg-white p-8 shadow-lg">
               
               <!-- Information General Section -->

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.html
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.html
@@ -53,7 +53,7 @@
               <span class="text-base font-medium">Tiempo estimado: 45-90 días</span>
             </div>
             
-            <div class="w-px h-6 bg-green-300"></div>
+            <div class="h-6 w-px bg-green-300"></div>
             
             <div class="flex items-center gap-2">
               <!-- Money Icon -->

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.html
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.html
@@ -169,7 +169,7 @@
 
         <!-- Main Form Content -->
         <div class="flex-1">
-          <div class="bg-white rounded-2xl shadow-lg p-12">
+          <div class="rounded-2xl bg-white p-12 shadow-lg">
             
             <!-- Form Header -->
             <div class="mb-8">

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.html
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.html
@@ -71,7 +71,7 @@
   <!-- Form Section -->
   <section class="px-4 py-16 sm:px-6 lg:px-8">
     <div class="mx-auto max-w-7xl">
-      <div class="flex gap-8">
+      <div class="flex gap-8 lg:flex-row flex-col">
         
         <!-- Sidebar Navigation -->
         <div class="w-80 shrink-0">

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.scss
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.scss
@@ -1,0 +1,87 @@
+// Custom scrollbar for sidebar
+.overflow-y-auto {
+  scrollbar-width: thin;
+  scrollbar-color: rgb(209, 213, 219) transparent;
+}
+
+.overflow-y-auto::-webkit-scrollbar {
+  width: 6px;
+}
+
+.overflow-y-auto::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.overflow-y-auto::-webkit-scrollbar-thumb {
+  background-color: rgb(209, 213, 219);
+  border-radius: 3px;
+}
+
+.overflow-y-auto::-webkit-scrollbar-thumb:hover {
+  background-color: rgb(156, 163, 175);
+}
+
+// Responsive design improvements
+@media (max-width: 1024px) {
+  .sticky {
+    position: relative !important;
+    top: auto !important;
+  }
+}
+
+@media (max-width: 768px) {
+  .flex.gap-8 {
+    flex-direction: column;
+    gap: 2rem;
+  }
+  
+  .w-80 {
+    width: 100%;
+  }
+  
+  .max-h-\[819px\] {
+    max-height: none;
+  }
+  
+  .grid-cols-2 {
+    grid-template-columns: 1fr;
+  }
+}
+
+// Animation for step transitions
+.step-item {
+  transition: all 0.2s ease-in-out;
+}
+
+.step-item:hover {
+  transform: translateX(2px);
+}
+
+// Button hover effects
+button[type="button"]:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+button[type="button"]:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+// Form validation styling
+.form-field.error {
+  border-color: #ef4444;
+}
+
+.form-field.error:focus {
+  ring-color: #ef4444;
+  border-color: #ef4444;
+}
+
+// Custom focus states for better accessibility
+button:focus-visible,
+input:focus-visible,
+select:focus-visible {
+  outline: 2px solid #059669;
+  outline-offset: 2px;
+}

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.scss
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.scss
@@ -21,31 +21,34 @@
   background-color: rgb(156, 163, 175);
 }
 
-// Responsive design improvements
-@media (max-width: 1024px) {
+// Responsive design improvements using modern CSS
+@container (max-width: 1024px) {
   .sticky {
     position: relative !important;
     top: auto !important;
   }
 }
 
+// Use modern Flexbox and Grid responsiveness
 @media (max-width: 768px) {
   .flex.gap-8 {
     flex-direction: column;
     gap: 2rem;
   }
-  
+
   .w-80 {
     width: 100%;
   }
-  
+
   .max-h-\[819px\] {
     max-height: none;
   }
-  
-  .grid-cols-2 {
-    grid-template-columns: 1fr;
-  }
+}
+
+// Modern aspect ratio and sizing
+.hero-section {
+  aspect-ratio: 16 / 9;
+  min-height: 525px;
 }
 
 // Animation for step transitions

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.ts
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.ts
@@ -1,0 +1,264 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { HeaderComponent } from '../../components/shared/header/header.component';
+import { FooterComponent } from '../../components/shared/footer/footer.component';
+
+@Component({
+  selector: 'app-tramites-beta',
+  imports: [
+    CommonModule,
+    FormsModule,
+    RouterModule,
+    HeaderComponent,
+    FooterComponent,
+  ],
+  templateUrl: './tramites-beta-page.component.html',
+  styleUrl: './tramites-beta-page.component.scss',
+})
+export class TramitesBetaPageComponent {
+  selectedTipoActividad = '';
+  currentStep = 1;
+  totalSteps = 35;
+
+  tiposActividad = [
+    'Evaluación ambiental inicial categoría C',
+    'Diagnóstico ambiental categoría C',
+    'Evaluación ambiental inicial categoría C+PGA',
+    'Diagnóstico ambiental categoría C+PGA5',
+    'Evaluación ambiental inicial actividades de registro',
+    'Diagnóstico ambiental actividades de registro',
+    'Evaluación ambiental inicial categoría B2',
+    'Diagnóstico ambiental categoría B2'
+  ];
+
+  formSteps = [
+    {
+      numero: 1,
+      titulo: 'Información del proyecto',
+      descripcion: 'Detalles del proyecto ambiental',
+      estado: 'active' // 'active', 'pending', 'completed'
+    },
+    {
+      numero: 2,
+      titulo: 'Información legal (persona individual o jurídica)',
+      descripcion: 'Datos del proponente',
+      estado: 'pending'
+    },
+    {
+      numero: 3,
+      titulo: 'Información de contacto del proponente',
+      descripcion: 'Datos de contacto',
+      estado: 'pending'
+    },
+    {
+      numero: 4,
+      titulo: 'Información de empresa consultora o consultor ambiental',
+      descripcion: 'Datos del consultor ambiental',
+      estado: 'pending'
+    },
+    {
+      numero: 5,
+      titulo: 'Fase de desarrollo del proyecto',
+      descripcion: 'Etapas del proyecto',
+      estado: 'pending'
+    },
+    {
+      numero: 6,
+      titulo: 'Descripción del proyecto',
+      descripcion: 'Detalles operativos',
+      estado: 'pending'
+    },
+    {
+      numero: 7,
+      titulo: 'Áreas del proyecto',
+      descripcion: 'Dimensiones y ubicación',
+      estado: 'pending'
+    },
+    {
+      numero: 8,
+      titulo: 'Descripción del entorno',
+      descripcion: 'Actividades colindantes',
+      estado: 'pending'
+    },
+    {
+      numero: 9,
+      titulo: 'Fases del proyecto',
+      descripcion: 'Descripción de actividades',
+      estado: 'pending'
+    },
+    {
+      numero: 10,
+      titulo: 'Fase de construcción',
+      descripcion: 'Actividades e insumos',
+      estado: 'pending'
+    },
+    {
+      numero: 11,
+      titulo: 'Fase de operación',
+      descripcion: 'Procesos y personal',
+      estado: 'pending'
+    },
+    {
+      numero: 12,
+      titulo: 'Servicios básicos',
+      descripcion: 'Abastecimientos y servicios',
+      estado: 'pending'
+    }
+  ];
+
+  impactosAmbientales = [
+    {
+      numero: 13,
+      titulo: 'Impactos ambientales y medidas de mitigación',
+      descripcion: 'Impacto a la atmósfera (construcción)',
+      estado: 'pending'
+    },
+    {
+      numero: 14,
+      titulo: 'Impactos a la atmósfera (operación)',
+      descripcion: 'Operación del proyecto',
+      estado: 'pending'
+    },
+    {
+      numero: 15,
+      titulo: 'Impactos al agua',
+      descripcion: 'Acuerdo gubernativo 236-2006',
+      estado: 'pending'
+    },
+    {
+      numero: 16,
+      titulo: 'Aguas residuales',
+      descripcion: 'Tipo de agua residual generada',
+      estado: 'pending'
+    },
+    {
+      numero: 17,
+      titulo: 'Fase construcción tipo de agua residual que genera',
+      descripcion: 'Aguas residuales construcción',
+      estado: 'pending'
+    },
+    {
+      numero: 18,
+      titulo: 'Fase operación tipo de agua residual que genera',
+      descripcion: 'Aguas residuales operación',
+      estado: 'pending'
+    },
+    {
+      numero: 19,
+      titulo: 'Construcción',
+      descripcion: 'Puntos de descarga construcción',
+      estado: 'pending'
+    },
+    {
+      numero: 20,
+      titulo: 'Operación',
+      descripcion: 'Puntos de descarga operación',
+      estado: 'pending'
+    },
+    {
+      numero: 21,
+      titulo: 'Reuso de aguas residuales',
+      descripcion: 'Aprovechamiento de aguas',
+      estado: 'pending'
+    },
+    {
+      numero: 22,
+      titulo: 'Impactos al suelo',
+      descripcion: 'Cambio de uso de suelo',
+      estado: 'pending'
+    },
+    {
+      numero: 23,
+      titulo: 'Geomorfología',
+      descripcion: 'Alteraciones geomorfológicas',
+      estado: 'pending'
+    },
+    {
+      numero: 24,
+      titulo: 'Residuos y desechos comunes',
+      descripcion: 'Gestión de residuos comunes',
+      estado: 'pending'
+    },
+    {
+      numero: 25,
+      titulo: 'Residuos y desechos especiales',
+      descripcion: 'Gestión de residuos especiales',
+      estado: 'pending'
+    },
+    {
+      numero: 26,
+      titulo: 'Residuos y desechos peligrosos',
+      descripcion: 'Gestión de residuos peligrosos',
+      estado: 'pending'
+    },
+    {
+      numero: 27,
+      titulo: 'Elementos bióticos, socioeconómicos, culturales y estéticos',
+      descripcion: 'Impactos al elemento biótico',
+      estado: 'pending'
+    },
+    {
+      numero: 28,
+      titulo: 'Elementos socioeconómicos y culturales',
+      descripcion: 'Impactos socioeconómicos',
+      estado: 'pending'
+    },
+    {
+      numero: 29,
+      titulo: 'Impacto a los elementos estéticos',
+      descripcion: 'Alteraciones estéticas',
+      estado: 'pending'
+    }
+  ];
+
+  requisitos = [
+    {
+      numero: 30,
+      titulo: 'Documentos técnicos',
+      descripcion: 'Documentación técnica requerida',
+      estado: 'pending'
+    },
+    {
+      numero: 31,
+      titulo: 'Complementarios',
+      descripcion: 'Documentos complementarios',
+      estado: 'pending'
+    },
+    {
+      numero: 32,
+      titulo: 'Específicos',
+      descripcion: 'Documentos específicos',
+      estado: 'pending'
+    },
+    {
+      numero: 33,
+      titulo: 'Específicos para actividades relacionadas con gestión integrada de residuos y desechos sólidos comunes',
+      descripcion: 'Gestión de residuos sólidos',
+      estado: 'pending'
+    },
+    {
+      numero: 34,
+      titulo: 'Documentos legales',
+      descripcion: 'Documentación legal',
+      estado: 'pending'
+    }
+  ];
+
+  selectTipoActividad(tipo: string) {
+    this.selectedTipoActividad = tipo;
+  }
+
+  goToPrevious() {
+    if (this.currentStep > 1) {
+      this.currentStep--;
+    }
+  }
+
+  goToNext() {
+    if (this.currentStep < this.totalSteps) {
+      this.currentStep++;
+    }
+  }
+}

--- a/src/app/pages/tramites-beta/tramites-beta-page.component.ts
+++ b/src/app/pages/tramites-beta/tramites-beta-page.component.ts
@@ -1,12 +1,12 @@
-import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
-import { RouterModule } from '@angular/router';
-import { HeaderComponent } from '../../components/shared/header/header.component';
-import { FooterComponent } from '../../components/shared/footer/footer.component';
+import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { FormsModule } from "@angular/forms";
+import { RouterModule } from "@angular/router";
+import { HeaderComponent } from "../../components/shared/header/header.component";
+import { FooterComponent } from "../../components/shared/footer/footer.component";
 
 @Component({
-  selector: 'app-tramites-beta',
+  selector: "app-tramites-beta",
   imports: [
     CommonModule,
     FormsModule,
@@ -14,236 +14,237 @@ import { FooterComponent } from '../../components/shared/footer/footer.component
     HeaderComponent,
     FooterComponent,
   ],
-  templateUrl: './tramites-beta-page.component.html',
-  styleUrl: './tramites-beta-page.component.scss',
+  templateUrl: "./tramites-beta-page.component.html",
+  styleUrl: "./tramites-beta-page.component.scss",
 })
 export class TramitesBetaPageComponent {
-  selectedTipoActividad = '';
+  selectedTipoActividad = "";
   currentStep = 1;
   totalSteps = 35;
 
   tiposActividad = [
-    'Evaluación ambiental inicial categoría C',
-    'Diagnóstico ambiental categoría C',
-    'Evaluación ambiental inicial categoría C+PGA',
-    'Diagnóstico ambiental categoría C+PGA5',
-    'Evaluación ambiental inicial actividades de registro',
-    'Diagnóstico ambiental actividades de registro',
-    'Evaluación ambiental inicial categoría B2',
-    'Diagnóstico ambiental categoría B2'
+    "Evaluación ambiental inicial categoría C",
+    "Diagnóstico ambiental categoría C",
+    "Evaluación ambiental inicial categoría C+PGA",
+    "Diagnóstico ambiental categoría C+PGA5",
+    "Evaluación ambiental inicial actividades de registro",
+    "Diagnóstico ambiental actividades de registro",
+    "Evaluación ambiental inicial categoría B2",
+    "Diagnóstico ambiental categoría B2",
   ];
 
   formSteps = [
     {
       numero: 1,
-      titulo: 'Información del proyecto',
-      descripcion: 'Detalles del proyecto ambiental',
-      estado: 'active' // 'active', 'pending', 'completed'
+      titulo: "Información del proyecto",
+      descripcion: "Detalles del proyecto ambiental",
+      estado: "active", // 'active', 'pending', 'completed'
     },
     {
       numero: 2,
-      titulo: 'Información legal (persona individual o jurídica)',
-      descripcion: 'Datos del proponente',
-      estado: 'pending'
+      titulo: "Información legal (persona individual o jurídica)",
+      descripcion: "Datos del proponente",
+      estado: "pending",
     },
     {
       numero: 3,
-      titulo: 'Información de contacto del proponente',
-      descripcion: 'Datos de contacto',
-      estado: 'pending'
+      titulo: "Información de contacto del proponente",
+      descripcion: "Datos de contacto",
+      estado: "pending",
     },
     {
       numero: 4,
-      titulo: 'Información de empresa consultora o consultor ambiental',
-      descripcion: 'Datos del consultor ambiental',
-      estado: 'pending'
+      titulo: "Información de empresa consultora o consultor ambiental",
+      descripcion: "Datos del consultor ambiental",
+      estado: "pending",
     },
     {
       numero: 5,
-      titulo: 'Fase de desarrollo del proyecto',
-      descripcion: 'Etapas del proyecto',
-      estado: 'pending'
+      titulo: "Fase de desarrollo del proyecto",
+      descripcion: "Etapas del proyecto",
+      estado: "pending",
     },
     {
       numero: 6,
-      titulo: 'Descripción del proyecto',
-      descripcion: 'Detalles operativos',
-      estado: 'pending'
+      titulo: "Descripción del proyecto",
+      descripcion: "Detalles operativos",
+      estado: "pending",
     },
     {
       numero: 7,
-      titulo: 'Áreas del proyecto',
-      descripcion: 'Dimensiones y ubicación',
-      estado: 'pending'
+      titulo: "Áreas del proyecto",
+      descripcion: "Dimensiones y ubicación",
+      estado: "pending",
     },
     {
       numero: 8,
-      titulo: 'Descripción del entorno',
-      descripcion: 'Actividades colindantes',
-      estado: 'pending'
+      titulo: "Descripción del entorno",
+      descripcion: "Actividades colindantes",
+      estado: "pending",
     },
     {
       numero: 9,
-      titulo: 'Fases del proyecto',
-      descripcion: 'Descripción de actividades',
-      estado: 'pending'
+      titulo: "Fases del proyecto",
+      descripcion: "Descripción de actividades",
+      estado: "pending",
     },
     {
       numero: 10,
-      titulo: 'Fase de construcción',
-      descripcion: 'Actividades e insumos',
-      estado: 'pending'
+      titulo: "Fase de construcción",
+      descripcion: "Actividades e insumos",
+      estado: "pending",
     },
     {
       numero: 11,
-      titulo: 'Fase de operación',
-      descripcion: 'Procesos y personal',
-      estado: 'pending'
+      titulo: "Fase de operación",
+      descripcion: "Procesos y personal",
+      estado: "pending",
     },
     {
       numero: 12,
-      titulo: 'Servicios básicos',
-      descripcion: 'Abastecimientos y servicios',
-      estado: 'pending'
-    }
+      titulo: "Servicios básicos",
+      descripcion: "Abastecimientos y servicios",
+      estado: "pending",
+    },
   ];
 
   impactosAmbientales = [
     {
       numero: 13,
-      titulo: 'Impactos ambientales y medidas de mitigación',
-      descripcion: 'Impacto a la atmósfera (construcción)',
-      estado: 'pending'
+      titulo: "Impactos ambientales y medidas de mitigación",
+      descripcion: "Impacto a la atmósfera (construcción)",
+      estado: "pending",
     },
     {
       numero: 14,
-      titulo: 'Impactos a la atmósfera (operación)',
-      descripcion: 'Operación del proyecto',
-      estado: 'pending'
+      titulo: "Impactos a la atmósfera (operación)",
+      descripcion: "Operación del proyecto",
+      estado: "pending",
     },
     {
       numero: 15,
-      titulo: 'Impactos al agua',
-      descripcion: 'Acuerdo gubernativo 236-2006',
-      estado: 'pending'
+      titulo: "Impactos al agua",
+      descripcion: "Acuerdo gubernativo 236-2006",
+      estado: "pending",
     },
     {
       numero: 16,
-      titulo: 'Aguas residuales',
-      descripcion: 'Tipo de agua residual generada',
-      estado: 'pending'
+      titulo: "Aguas residuales",
+      descripcion: "Tipo de agua residual generada",
+      estado: "pending",
     },
     {
       numero: 17,
-      titulo: 'Fase construcción tipo de agua residual que genera',
-      descripcion: 'Aguas residuales construcción',
-      estado: 'pending'
+      titulo: "Fase construcción tipo de agua residual que genera",
+      descripcion: "Aguas residuales construcción",
+      estado: "pending",
     },
     {
       numero: 18,
-      titulo: 'Fase operación tipo de agua residual que genera',
-      descripcion: 'Aguas residuales operación',
-      estado: 'pending'
+      titulo: "Fase operación tipo de agua residual que genera",
+      descripcion: "Aguas residuales operación",
+      estado: "pending",
     },
     {
       numero: 19,
-      titulo: 'Construcción',
-      descripcion: 'Puntos de descarga construcción',
-      estado: 'pending'
+      titulo: "Construcción",
+      descripcion: "Puntos de descarga construcción",
+      estado: "pending",
     },
     {
       numero: 20,
-      titulo: 'Operación',
-      descripcion: 'Puntos de descarga operación',
-      estado: 'pending'
+      titulo: "Operación",
+      descripcion: "Puntos de descarga operación",
+      estado: "pending",
     },
     {
       numero: 21,
-      titulo: 'Reuso de aguas residuales',
-      descripcion: 'Aprovechamiento de aguas',
-      estado: 'pending'
+      titulo: "Reuso de aguas residuales",
+      descripcion: "Aprovechamiento de aguas",
+      estado: "pending",
     },
     {
       numero: 22,
-      titulo: 'Impactos al suelo',
-      descripcion: 'Cambio de uso de suelo',
-      estado: 'pending'
+      titulo: "Impactos al suelo",
+      descripcion: "Cambio de uso de suelo",
+      estado: "pending",
     },
     {
       numero: 23,
-      titulo: 'Geomorfología',
-      descripcion: 'Alteraciones geomorfológicas',
-      estado: 'pending'
+      titulo: "Geomorfología",
+      descripcion: "Alteraciones geomorfológicas",
+      estado: "pending",
     },
     {
       numero: 24,
-      titulo: 'Residuos y desechos comunes',
-      descripcion: 'Gestión de residuos comunes',
-      estado: 'pending'
+      titulo: "Residuos y desechos comunes",
+      descripcion: "Gestión de residuos comunes",
+      estado: "pending",
     },
     {
       numero: 25,
-      titulo: 'Residuos y desechos especiales',
-      descripcion: 'Gestión de residuos especiales',
-      estado: 'pending'
+      titulo: "Residuos y desechos especiales",
+      descripcion: "Gestión de residuos especiales",
+      estado: "pending",
     },
     {
       numero: 26,
-      titulo: 'Residuos y desechos peligrosos',
-      descripcion: 'Gestión de residuos peligrosos',
-      estado: 'pending'
+      titulo: "Residuos y desechos peligrosos",
+      descripcion: "Gestión de residuos peligrosos",
+      estado: "pending",
     },
     {
       numero: 27,
-      titulo: 'Elementos bióticos, socioeconómicos, culturales y estéticos',
-      descripcion: 'Impactos al elemento biótico',
-      estado: 'pending'
+      titulo: "Elementos bióticos, socioeconómicos, culturales y estéticos",
+      descripcion: "Impactos al elemento biótico",
+      estado: "pending",
     },
     {
       numero: 28,
-      titulo: 'Elementos socioeconómicos y culturales',
-      descripcion: 'Impactos socioeconómicos',
-      estado: 'pending'
+      titulo: "Elementos socioeconómicos y culturales",
+      descripcion: "Impactos socioeconómicos",
+      estado: "pending",
     },
     {
       numero: 29,
-      titulo: 'Impacto a los elementos estéticos',
-      descripcion: 'Alteraciones estéticas',
-      estado: 'pending'
-    }
+      titulo: "Impacto a los elementos estéticos",
+      descripcion: "Alteraciones estéticas",
+      estado: "pending",
+    },
   ];
 
   requisitos = [
     {
       numero: 30,
-      titulo: 'Documentos técnicos',
-      descripcion: 'Documentación técnica requerida',
-      estado: 'pending'
+      titulo: "Documentos técnicos",
+      descripcion: "Documentación técnica requerida",
+      estado: "pending",
     },
     {
       numero: 31,
-      titulo: 'Complementarios',
-      descripcion: 'Documentos complementarios',
-      estado: 'pending'
+      titulo: "Complementarios",
+      descripcion: "Documentos complementarios",
+      estado: "pending",
     },
     {
       numero: 32,
-      titulo: 'Específicos',
-      descripcion: 'Documentos específicos',
-      estado: 'pending'
+      titulo: "Específicos",
+      descripcion: "Documentos específicos",
+      estado: "pending",
     },
     {
       numero: 33,
-      titulo: 'Específicos para actividades relacionadas con gestión integrada de residuos y desechos sólidos comunes',
-      descripcion: 'Gestión de residuos sólidos',
-      estado: 'pending'
+      titulo:
+        "Específicos para actividades relacionadas con gestión integrada de residuos y desechos sólidos comunes",
+      descripcion: "Gestión de residuos sólidos",
+      estado: "pending",
     },
     {
       numero: 34,
-      titulo: 'Documentos legales',
-      descripcion: 'Documentación legal',
-      estado: 'pending'
-    }
+      titulo: "Documentos legales",
+      descripcion: "Documentación legal",
+      estado: "pending",
+    },
   ];
 
   selectTipoActividad(tipo: string) {

--- a/src/app/pages/tramites/tramites-page.component.ts
+++ b/src/app/pages/tramites/tramites-page.component.ts
@@ -1,11 +1,11 @@
-import {Component, computed, signal} from "@angular/core";
+import { Component, computed, signal } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { FormsModule } from "@angular/forms";
 import { MatIconModule } from "@angular/material/icon";
 import { RouterModule } from "@angular/router";
 import { HeaderComponent } from "../../components/shared/header/header.component";
 import { FooterComponent } from "../../components/shared/footer/footer.component";
-import { TramiteCardComponent } from '../../components/pages/tramites/tramite-card/tramite-card.component';
+import { TramiteCardComponent } from "../../components/pages/tramites/tramite-card/tramite-card.component";
 
 @Component({
   selector: "app-tramites",
@@ -22,23 +22,23 @@ import { TramiteCardComponent } from '../../components/pages/tramites/tramite-ca
   styleUrl: "./tramites-page.component.scss",
 })
 export class TramitesPageComponent {
-  busqueda = signal('');
-  categoriaSeleccionada = signal('');
+  busqueda = signal("");
+  categoriaSeleccionada = signal("");
 
   categorias = signal([
     {
       id: "ambiental",
-      name: "Ambiental"
+      name: "Ambiental",
     },
     {
       id: "construccion",
-      name: "Construcción"
+      name: "Construcción",
     },
     { id: "salud", name: "Salud" },
     { id: "agricola", name: "Agrícola" },
     {
       id: "economico",
-      name: "Económico"
+      name: "Económico",
     },
   ]);
 
@@ -70,7 +70,7 @@ export class TramitesPageComponent {
       categoria: "ambiental",
       ministerio: "marn",
       duracion: "45-90 días",
-      link: "/tramites-beta"
+      link: "/tramites-beta",
     },
     {
       id: 1,
@@ -146,7 +146,7 @@ export class TramitesPageComponent {
     },
   ]);
 
-  tramitesFiltrados = computed(() =>{
+  tramitesFiltrados = computed(() => {
     return this.tramites().filter((tramite) => {
       const busquedaEncontrada =
         tramite.titulo.toLowerCase().includes(this.busqueda().toLowerCase()) ||
@@ -154,11 +154,12 @@ export class TramitesPageComponent {
           .toLowerCase()
           .includes(this.busqueda().toLowerCase());
       const busquedaCategoria =
-        !this.categoriaSeleccionada() || tramite.categoria === this.categoriaSeleccionada();
+        !this.categoriaSeleccionada() ||
+        tramite.categoria === this.categoriaSeleccionada();
 
       return busquedaEncontrada && busquedaCategoria;
     });
-  })
+  });
 
   clearFilters() {
     this.busqueda.set("");

--- a/src/app/pages/tramites/tramites-page.component.ts
+++ b/src/app/pages/tramites/tramites-page.component.ts
@@ -70,7 +70,6 @@ export class TramitesPageComponent {
       categoria: "ambiental",
       ministerio: "marn",
       duracion: "45-90 días",
-      isBeta: true,
       link: "/tramites-beta"
     },
     {

--- a/src/app/pages/tramites/tramites-page.component.ts
+++ b/src/app/pages/tramites/tramites-page.component.ts
@@ -63,6 +63,17 @@ export class TramitesPageComponent {
 
   tramites = signal([
     {
+      id: 0,
+      titulo: "Formulario Instrumento Ambiental Bajo Impacto (FIABI)",
+      descripcion:
+        "Complete el proceso de evaluación ambiental para proyectos de bajo impacto de manera digital y eficiente.",
+      categoria: "ambiental",
+      ministerio: "marn",
+      duracion: "45-90 días",
+      isBeta: true,
+      link: "/tramites-beta"
+    },
+    {
       id: 1,
       titulo: "Licencia Ambiental para Proyectos Industriales",
       descripcion:


### PR DESCRIPTION
## Purpose

The user requested to remove the beta design from the new functionality and make it consistent with other tramites, while implementing the header background image from the Figma design. They also requested to use Tailwind v4 as much as possible and include SCSS classes when necessary. The user specifically mentioned that the header should have a green filter effect as shown in the Figma design.

## Code changes

- **Added new route**: Created `/tramites-beta` route pointing to `TramitesBetaPageComponent`
- **Created beta tramites page**: New component `TramitesBetaPageComponent` with comprehensive form steps for environmental impact assessment
- **Enhanced tramite cards**: Added conditional routing support with `routerLink` for tramites that have a `link` property
- **Updated header navigation**: Added "Trámites Beta" link in the desktop navigation menu
- **Added new tramite entry**: Created FIABI (Formulario Instrumento Ambiental Bajo Impacto) tramite that links to the beta page
- **Code formatting**: Standardized quote usage from single to double quotes across routing and component files
- **Import updates**: Added necessary Angular modules (RouterModule, CommonModule) to support new functionality

The implementation includes a multi-step form with 35 total steps covering project information, legal details, environmental impacts, and document requirements for environmental assessment processes.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7e6f1b37ac8c4ec8a4ea34a882b04385/vortex-home)

👀 [Preview Link](https://7e6f1b37ac8c4ec8a4ea34a882b04385-vortex-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7e6f1b37ac8c4ec8a4ea34a882b04385</projectId>-->
<!--<branchName>vortex-home</branchName>-->